### PR TITLE
Use the alert(unwrapping:case:) API.

### DIFF
--- a/Examples/Inventory/ItemRow.swift
+++ b/Examples/Inventory/ItemRow.swift
@@ -115,8 +115,9 @@ struct ItemRowView: View {
       .buttonStyle(.plain)
       .foregroundColor(self.viewModel.item.status.isInStock ? nil : Color.gray)
       .alert(
-        self.viewModel.item.name,
-        isPresented: self.$viewModel.route.isPresent(/ItemRowViewModel.Route.deleteAlert),
+        title: { Text(self.viewModel.item.name) },
+        unwrapping: self.$viewModel.route,
+        case: /ItemRowViewModel.Route.deleteAlert,
         actions: {
           Button("Delete", role: .destructive) {
             self.viewModel.deleteConfirmationButtonTapped()


### PR DESCRIPTION
Seems better for the purpose of the example apps to only use our APIs instead of the SwiftUI ones. What do you think?

There may be other ways to demonstrate the binding transformations with case studies if we want to show off those APIs.