### PR TITLE
Use recommended NavagationLink init

### DIFF
--- a/Sources/SwiftUINavigation/NavigationLink.swift
+++ b/Sources/SwiftUINavigation/NavigationLink.swift
@@ -49,8 +49,10 @@ extension NavigationLink {
     @ViewBuilder label: @escaping () -> Label
   ) where Destination == WrappedDestination? {
     self.init(
-      destination: Binding(unwrapping: value).map(destination),
       isActive: value.isPresent().didSet(onNavigate),
+      destination: {
+        Binding(unwrapping: value).map(destination)
+      },
       label: label
     )
   }


### PR DESCRIPTION
Apple's online documentation says that the version of `NavigationLink.init` being uses is deprecated.

https://developer.apple.com/documentation/swiftui/navigationlink/init(destination:isactive:label:)