### PR TITLE
Add `Binding.removeDuplicates()`

### DIFF
--- a/Sources/SwiftUINavigation/Binding.swift
+++ b/Sources/SwiftUINavigation/Binding.swift
@@ -133,4 +133,34 @@ extension Binding {
   where Value == Enum? {
     self.case(casePath).isPresent()
   }
+
+  /// Creates a binding that ignores writes to its wrapped value when equivalent to the new value.
+  ///
+  /// Useful to minimize writes to bindings passed to SwiftUI APIs. For example, `NavigationLink`
+  /// may write `nil` twice when dismissing its destination via the navigation bar's back button.
+  /// Logic attached to this dismissal will execute twice, which may not be desirable.
+  ///
+  /// - Parameter isDuplicate: A closure to evaluate whether two elements are equivalent, for
+  ///   purposes of filtering writes. Return `true` from this closure to indicate that the second
+  ///   element is a duplicate of the first.
+  public func removeDuplicates(by isDuplicate: @escaping (Value, Value) -> Bool) -> Self {
+    .init(
+      get: { self.wrappedValue },
+      set: { newValue, transaction in
+        guard !isDuplicate(self.wrappedValue, newValue) else { return }
+        self.transaction(transaction).wrappedValue = newValue
+      }
+    )
+  }
+}
+
+extension Binding where Value: Equatable {
+  /// Creates a binding that ignores writes to its wrapped value when equivalent to the new value.
+  ///
+  /// Useful to minimize writes to bindings passed to SwiftUI APIs. For example, `NavigationLink`
+  /// may write `nil` twice when dismissing its destination via the navigation bar's back button.
+  /// Logic attached to this dismissal will execute twice, which may not be desirable.
+  public func removeDuplicates() -> Self {
+    self.removeDuplicates(by: ==)
+  }
 }


### PR DESCRIPTION
Because this library makes it easy to add logic around navigation, it's probably also a good idea to ship with helpers that work around some surprising bugs/behaviors that currently exist in SwiftUI. For example, as noticed by #10, `NavigationLink` writes `nil` to its binding twice on dismissal.

It's probably not appropriate for us to automatically filter duplicate writes, but we can at least ship a `Binding.removeDuplicates()` that makes it easy to achieve this behavior.
