### PR TITLE
NavigationLink updates; less escaping

### DIFF
--- a/Examples/CaseStudies/06-NavigationLinks.swift
+++ b/Examples/CaseStudies/06-NavigationLinks.swift
@@ -10,28 +10,26 @@ struct OptionalNavigationLinks: View {
         Stepper("Number: \(self.viewModel.count)", value: self.$viewModel.count)
 
         HStack {
-          NavigationLink(
-            unwrapping: self.$viewModel.fact,
-            destination: { $fact in
-              FactEditor(fact: $fact.description)
-                .disabled(self.viewModel.isLoading)
-                .foregroundColor(self.viewModel.isLoading ? .gray : nil)
-                .navigationBarBackButtonHidden(true)
-                .toolbar {
-                  ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") {
-                      self.viewModel.cancelButtonTapped()
-                    }
-                  }
-                  ToolbarItem(placement: .confirmationAction) {
-                    Button("Save") {
-                      self.viewModel.saveButtonTapped(fact: fact)
-                    }
+          NavigationLink(unwrapping: self.$viewModel.fact) {
+            self.viewModel.setFactNavigation(isActive: $0)
+          } destination: { $fact in
+            FactEditor(fact: $fact.description)
+              .disabled(self.viewModel.isLoading)
+              .foregroundColor(self.viewModel.isLoading ? .gray : nil)
+              .navigationBarBackButtonHidden(true)
+              .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                  Button("Cancel") {
+                    self.viewModel.cancelButtonTapped()
                   }
                 }
-            },
-            onNavigate: { self.viewModel.setFactNavigation(isActive: $0) }
-          ) {
+                ToolbarItem(placement: .confirmationAction) {
+                  Button("Save") {
+                    self.viewModel.saveButtonTapped(fact: fact)
+                  }
+                }
+              }
+          } label: {
             Text("Get number fact")
           }
 

--- a/Examples/CaseStudies/07-NavigationLinkList.swift
+++ b/Examples/CaseStudies/07-NavigationLinkList.swift
@@ -61,7 +61,9 @@ private struct RowView: View {
     NavigationLink(
       unwrapping: self.$viewModel.route,
       case: /ListOfNavigationLinksRowViewModel.Route.edit
-    ) { $counter in
+    ) {
+      self.viewModel.setEditNavigation(isActive: $0)
+    } destination: { $counter in
       EditView(counter: $counter)
         .navigationBarBackButtonHidden(true)
         .toolbar {
@@ -72,8 +74,6 @@ private struct RowView: View {
             Button("Cancel") { self.viewModel.cancelButtonTapped() }
           }
         }
-    } onNavigate: {
-      self.viewModel.setEditNavigation(isActive: $0)
     } label: {
       Text("\(self.viewModel.counter)")
     }

--- a/Examples/CaseStudies/08-Routing.swift
+++ b/Examples/CaseStudies/08-Routing.swift
@@ -47,12 +47,12 @@ struct Routing: View {
         }
       )
 
-      NavigationLink(unwrapping: self.$route, case: /Route.link) { $count in
+      NavigationLink(unwrapping: self.$route, case: /Route.link) {
+        self.route = $0 ? .link(0) : nil
+      } destination: { $count in
         Form {
           Stepper("Number: \(count)", value: $count)
         }
-      } onNavigate: {
-        self.route = $0 ? .link(0) : nil
       } label: {
         Text("Link")
       }

--- a/Examples/Inventory/ItemRow.swift
+++ b/Examples/Inventory/ItemRow.swift
@@ -62,7 +62,9 @@ struct ItemRowView: View {
   @ObservedObject var viewModel: ItemRowViewModel
 
   var body: some View {
-    NavigationLink(unwrapping: self.$viewModel.route, case: /ItemRowViewModel.Route.edit) { $item in
+    NavigationLink(unwrapping: self.$viewModel.route, case: /ItemRowViewModel.Route.edit) {
+      self.viewModel.setEditNavigation(isActive: $0)
+    } destination: { $item in
       ItemView(item: $item)
         .navigationBarTitle("Edit")
         .navigationBarBackButtonHidden(true)
@@ -78,8 +80,6 @@ struct ItemRowView: View {
             }
           }
         }
-    } onNavigate: {
-      self.viewModel.setEditNavigation(isActive: $0)
     } label: {
       HStack {
         VStack(alignment: .leading) {

--- a/Sources/SwiftUINavigation/Alert.swift
+++ b/Sources/SwiftUINavigation/Alert.swift
@@ -55,8 +55,8 @@
     public func alert<Value, A: View, M: View>(
       title: (Value) -> Text,
       unwrapping value: Binding<Value?>,
-      @ViewBuilder actions: @escaping (Value) -> A,
-      @ViewBuilder message: @escaping (Value) -> M
+      @ViewBuilder actions: (Value) -> A,
+      @ViewBuilder message: (Value) -> M
     ) -> some View {
       self.alert(
         value.wrappedValue.map(title) ?? Text(""),
@@ -88,8 +88,8 @@
       title: (Case) -> Text,
       unwrapping enum: Binding<Enum?>,
       case casePath: CasePath<Enum, Case>,
-      @ViewBuilder actions: @escaping (Case) -> A,
-      @ViewBuilder message: @escaping (Case) -> M
+      @ViewBuilder actions: (Case) -> A,
+      @ViewBuilder message: (Case) -> M
     ) -> some View {
       self.alert(
         title: title,

--- a/Sources/SwiftUINavigation/ConfirmationDialog.swift
+++ b/Sources/SwiftUINavigation/ConfirmationDialog.swift
@@ -58,8 +58,8 @@
       title: (Value) -> Text,
       titleVisibility: Visibility = .automatic,
       unwrapping value: Binding<Value?>,
-      @ViewBuilder actions: @escaping (Value) -> A,
-      @ViewBuilder message: @escaping (Value) -> M
+      @ViewBuilder actions: (Value) -> A,
+      @ViewBuilder message: (Value) -> M
     ) -> some View {
       self.confirmationDialog(
         value.wrappedValue.map(title) ?? Text(""),
@@ -94,8 +94,8 @@
       titleVisibility: Visibility = .automatic,
       unwrapping enum: Binding<Enum?>,
       case casePath: CasePath<Enum, Case>,
-      @ViewBuilder actions: @escaping (Case) -> A,
-      @ViewBuilder message: @escaping (Case) -> M
+      @ViewBuilder actions: (Case) -> A,
+      @ViewBuilder message: (Case) -> M
     ) -> some View {
       self.confirmationDialog(
         title: title,

--- a/Sources/SwiftUINavigation/IfCaseLet.swift
+++ b/Sources/SwiftUINavigation/IfCaseLet.swift
@@ -41,7 +41,7 @@ where IfContent: View, ElseContent: View {
   public let `enum`: Binding<Enum>
   public let casePath: CasePath<Enum, Case>
   public let ifContent: (Binding<Case>) -> IfContent
-  public let elseContent: () -> ElseContent
+  public let elseContent: ElseContent
 
   /// Computes content by extracting a case from a binding to an enum and passing a non-optional
   /// binding to the case's associated value to its content closure.
@@ -61,19 +61,19 @@ where IfContent: View, ElseContent: View {
     _ `enum`: Binding<Enum>,
     pattern casePath: CasePath<Enum, Case>,
     @ViewBuilder ifContent: @escaping (Binding<Case>) -> IfContent,
-    @ViewBuilder elseContent: @escaping () -> ElseContent
+    @ViewBuilder elseContent: () -> ElseContent
   ) {
     self.casePath = casePath
-    self.elseContent = elseContent
+    self.elseContent = elseContent()
     self.enum = `enum`
     self.ifContent = ifContent
   }
 
   public var body: some View {
-    if let caseBinding = Binding(unwrapping: self.enum, case: self.casePath) {
-      ifContent(caseBinding)
+    if let $case = Binding(unwrapping: self.enum, case: self.casePath) {
+      self.ifContent($case)
     } else {
-      elseContent()
+      self.elseContent
     }
   }
 }
@@ -85,7 +85,7 @@ extension IfCaseLet where ElseContent == EmptyView {
     @ViewBuilder ifContent: @escaping (Binding<Case>) -> IfContent
   ) {
     self.casePath = casePath
-    self.elseContent = { EmptyView() }
+    self.elseContent = EmptyView()
     self.enum = `enum`
     self.ifContent = ifContent
   }

--- a/Sources/SwiftUINavigation/IfLet.swift
+++ b/Sources/SwiftUINavigation/IfLet.swift
@@ -31,7 +31,7 @@
 public struct IfLet<Value, IfContent, ElseContent>: View where IfContent: View, ElseContent: View {
   public let value: Binding<Value?>
   public let ifContent: (Binding<Value>) -> IfContent
-  public let elseContent: () -> ElseContent
+  public let elseContent: ElseContent
 
   /// Computes content by unwrapping a binding to an optional and passing a non-optional binding to
   /// its content closure.
@@ -48,18 +48,18 @@ public struct IfLet<Value, IfContent, ElseContent>: View where IfContent: View, 
   public init(
     _ value: Binding<Value?>,
     @ViewBuilder then ifContent: @escaping (Binding<Value>) -> IfContent,
-    @ViewBuilder else elseContent: @escaping () -> ElseContent
+    @ViewBuilder else elseContent: () -> ElseContent
   ) {
     self.value = value
     self.ifContent = ifContent
-    self.elseContent = elseContent
+    self.elseContent = elseContent()
   }
 
   public var body: some View {
     if let $value = Binding(unwrapping: self.value) {
       self.ifContent($value)
     } else {
-      self.elseContent()
+      self.elseContent
     }
   }
 }

--- a/Sources/SwiftUINavigation/Internal/Deprecations.swift
+++ b/Sources/SwiftUINavigation/Internal/Deprecations.swift
@@ -1,0 +1,33 @@
+// NB: Deprecated after 0.2.0
+
+extension NavigationLink {
+  @available(*, deprecated, renamed: "init(unwrapping:onNavigate:destination:label:)")
+  public init<Value, WrappedDestination>(
+    unwrapping value: Binding<Value?>,
+    @ViewBuilder destination: @escaping (Binding<Value>) -> WrappedDestination,
+    onNavigate: @escaping (_ isActive: Bool) -> Void,
+    @ViewBuilder label: () -> Label
+  ) where Destination == WrappedDestination? {
+    self.init(
+      destination: Binding(unwrapping: value).map(destination),
+      isActive: value.isPresent().didSet(onNavigate),
+      label: label
+    )
+  }
+
+  @available(*, deprecated, renamed: "init(unwrapping:case:onNavigate:destination:label:)")
+  public init<Enum, Case, WrappedDestination>(
+    unwrapping enum: Binding<Enum?>,
+    case casePath: CasePath<Enum, Case>,
+    @ViewBuilder destination: @escaping (Binding<Case>) -> WrappedDestination,
+    onNavigate: @escaping (Bool) -> Void,
+    @ViewBuilder label: () -> Label
+  ) where Destination == WrappedDestination? {
+    self.init(
+      unwrapping: `enum`.case(casePath),
+      onNavigate: onNavigate,
+      destination: destination,
+      label: label
+    )
+  }
+}

--- a/Sources/SwiftUINavigation/NavigationLink.swift
+++ b/Sources/SwiftUINavigation/NavigationLink.swift
@@ -13,11 +13,11 @@ extension NavigationLink {
   ///
   ///   var body: some View {
   ///     ForEach(self.posts) { post in
-  ///       NavigationLink(unwrapping: self.$postToEdit) { $draft in
-  ///         EditPostView(post: $draft)
-  ///       } onNavigate: { isActive in
+  ///       NavigationLink(unwrapping: self.$postToEdit) { isActive in
   ///         self.postToEdit = isActive ? post : nil
-  ///       } label: {
+  ///       } destination: { $draft in
+  ///         EditPostView(post: $draft)
+  ///       } onNavigate:  label: {
   ///         Text(post.title)
   ///       }
   ///     }
@@ -36,17 +36,21 @@ extension NavigationLink {
   ///     destination can use this binding to produce its content and write changes back to the
   ///     source of truth. Upstream changes to `value` will also be instantly reflected in the
   ///     destination. If `value` becomes `nil`, the destination is dismissed.
-  ///   - destination: A view for the navigation link to present.
   ///   - onNavigate: A closure that executes when the link becomes active or inactive with a
   ///     boolean that describes if the link was activated or not. Use this closure to populate the
   ///     source of truth when it is passed a value of `true`. When passed `false`, the system will
   ///     automatically write `nil` to `value`.
+  ///   - destination: A view for the navigation link to present.
   ///   - label: A view builder to produce a label describing the `destination` to present.
+  @available(iOS, introduced: 13, deprecated: 16)
+  @available(macOS, introduced: 10.15, deprecated: 13)
+  @available(tvOS, introduced: 13, deprecated: 16)
+  @available(watchOS, introduced: 6, deprecated: 9)
   public init<Value, WrappedDestination>(
     unwrapping value: Binding<Value?>,
-    @ViewBuilder destination: @escaping (Binding<Value>) -> WrappedDestination,
     onNavigate: @escaping (_ isActive: Bool) -> Void,
-    @ViewBuilder label: @escaping () -> Label
+    @ViewBuilder destination: @escaping (Binding<Value>) -> WrappedDestination,
+    @ViewBuilder label: () -> Label
   ) where Destination == WrappedDestination? {
     self.init(
       destination: Binding(unwrapping: value).map(destination),
@@ -75,10 +79,10 @@ extension NavigationLink {
   ///
   ///   var body: some View {
   ///     ForEach(self.posts) { post in
-  ///       NavigationLink(unwrapping: self.$route, case: /Route.edit) { $draft in
-  ///         EditPostView(post: $draft)
-  ///       } onNavigate: { isActive in
+  ///       NavigationLink(unwrapping: self.$route, case: /Route.edit) { isActive in
   ///         self.route = isActive ? .edit(post) : nil
+  ///       } destination: { $draft in
+  ///         EditPostView(post: $draft)
   ///       } label: {
   ///         Text(post.title)
   ///       }
@@ -102,23 +106,27 @@ extension NavigationLink {
   ///     produce its content and write changes back to the source of truth. Upstream changes to
   ///     `enum` will also be instantly reflected in the destination. If `enum` becomes `nil`, the
   ///     destination is dismissed.
-  ///   - destination: A view for the navigation link to present.
   ///   - onNavigate: A closure that executes when the link becomes active or inactive with a
   ///     boolean that describes if the link was activated or not. Use this closure to populate the
   ///     source of truth when it is passed a value of `true`. When passed `false`, the system will
   ///     automatically write `nil` to `enum`.
+  ///   - destination: A view for the navigation link to present.
   ///   - label: A view builder to produce a label describing the `destination` to present.
+  @available(iOS, introduced: 13, deprecated: 16)
+  @available(macOS, introduced: 10.15, deprecated: 13)
+  @available(tvOS, introduced: 13, deprecated: 16)
+  @available(watchOS, introduced: 6, deprecated: 9)
   public init<Enum, Case, WrappedDestination>(
     unwrapping enum: Binding<Enum?>,
     case casePath: CasePath<Enum, Case>,
-    @ViewBuilder destination: @escaping (Binding<Case>) -> WrappedDestination,
     onNavigate: @escaping (Bool) -> Void,
-    @ViewBuilder label: @escaping () -> Label
+    @ViewBuilder destination: @escaping (Binding<Case>) -> WrappedDestination,
+    @ViewBuilder label: () -> Label
   ) where Destination == WrappedDestination? {
     self.init(
       unwrapping: `enum`.case(casePath),
-      destination: destination,
       onNavigate: onNavigate,
+      destination: destination,
       label: label
     )
   }

--- a/Sources/SwiftUINavigation/Switch.swift
+++ b/Sources/SwiftUINavigation/Switch.swift
@@ -40,20 +40,20 @@
 /// > Note: In debug builds, exhaustivity is handled at runtime: if the `Switch` encounters an
 /// > unhandled case, and no ``Default`` view is present, a runtime warning is issued and a warning
 /// > view is presented.
-public struct Switch<Enum, Content>: View where Content: View {
+public struct Switch<Enum, Content: View>: View {
   public let `enum`: Binding<Enum>
-  public let content: () -> Content
+  public let content: Content
 
   private init(
     enum: Binding<Enum>,
-    @ViewBuilder content: @escaping () -> Content
+    @ViewBuilder content: () -> Content
   ) {
     self.enum = `enum`
-    self.content = content
+    self.content = content()
   }
 
   public var body: some View {
-    self.content()
+    self.content
       .environmentObject(BindingObject(binding: self.enum))
   }
 }
@@ -89,27 +89,27 @@ where Content: View {
 /// If you wish to use ``Switch`` in a non-exhaustive manner (_i.e._, you do not want to provide a
 /// ``CaseLet`` for every case of the enum), then you must insert a ``Default`` view at the end of
 /// the ``Switch``'s body, or use ``IfCaseLet`` instead.
-public struct Default<Content>: View where Content: View {
-  private let content: () -> Content
+public struct Default<Content: View>: View {
+  private let content: Content
 
   /// Initializes a ``Default`` view that computes content depending on if a binding to enum state
   /// does not match a particular case.
   ///
   /// - Parameter content: A function that returns a view that is visible only when the switch
   ///   view's state does not match a preceding ``CaseLet`` view.
-  public init(@ViewBuilder content: @escaping () -> Content) {
-    self.content = content
+  public init(@ViewBuilder content: () -> Content) {
+    self.content = content()
   }
 
   public var body: some View {
-    self.content()
+    self.content
   }
 }
 
 extension Switch {
   public init<Case1, Content1, DefaultContent>(
     _ enum: Binding<Enum>,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<Enum, Case1, Content1>,
         Default<DefaultContent>
@@ -136,7 +136,7 @@ extension Switch {
     _ enum: Binding<Enum>,
     file: StaticString = #fileID,
     line: UInt = #line,
-    @ViewBuilder content: @escaping () -> CaseLet<Enum, Case1, Content1>
+    @ViewBuilder content: () -> CaseLet<Enum, Case1, Content1>
   )
   where
     Content == _ConditionalContent<
@@ -152,7 +152,7 @@ extension Switch {
 
   public init<Case1, Content1, Case2, Content2, DefaultContent>(
     _ enum: Binding<Enum>,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<Enum, Case1, Content1>,
         CaseLet<Enum, Case2, Content2>,
@@ -186,7 +186,7 @@ extension Switch {
     _ enum: Binding<Enum>,
     file: StaticString = #fileID,
     line: UInt = #line,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<Enum, Case1, Content1>,
         CaseLet<Enum, Case2, Content2>
@@ -217,7 +217,7 @@ extension Switch {
     DefaultContent
   >(
     _ enum: Binding<Enum>,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<Enum, Case1, Content1>,
         CaseLet<Enum, Case2, Content2>,
@@ -257,7 +257,7 @@ extension Switch {
     _ enum: Binding<Enum>,
     file: StaticString = #fileID,
     line: UInt = #line,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<Enum, Case1, Content1>,
         CaseLet<Enum, Case2, Content2>,
@@ -294,7 +294,7 @@ extension Switch {
     DefaultContent
   >(
     _ enum: Binding<Enum>,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<Enum, Case1, Content1>,
         CaseLet<Enum, Case2, Content2>,
@@ -345,7 +345,7 @@ extension Switch {
     _ enum: Binding<Enum>,
     file: StaticString = #fileID,
     line: UInt = #line,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<Enum, Case1, Content1>,
         CaseLet<Enum, Case2, Content2>,
@@ -388,7 +388,7 @@ extension Switch {
     DefaultContent
   >(
     _ enum: Binding<Enum>,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<Enum, Case1, Content1>,
         CaseLet<Enum, Case2, Content2>,
@@ -446,7 +446,7 @@ extension Switch {
     _ enum: Binding<Enum>,
     file: StaticString = #fileID,
     line: UInt = #line,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<Enum, Case1, Content1>,
         CaseLet<Enum, Case2, Content2>,
@@ -495,7 +495,7 @@ extension Switch {
     DefaultContent
   >(
     _ enum: Binding<Enum>,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<Enum, Case1, Content1>,
         CaseLet<Enum, Case2, Content2>,
@@ -560,7 +560,7 @@ extension Switch {
     _ enum: Binding<Enum>,
     file: StaticString = #fileID,
     line: UInt = #line,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<Enum, Case1, Content1>,
         CaseLet<Enum, Case2, Content2>,
@@ -615,7 +615,7 @@ extension Switch {
     DefaultContent
   >(
     _ enum: Binding<Enum>,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<Enum, Case1, Content1>,
         CaseLet<Enum, Case2, Content2>,
@@ -687,7 +687,7 @@ extension Switch {
     _ enum: Binding<Enum>,
     file: StaticString = #fileID,
     line: UInt = #line,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<Enum, Case1, Content1>,
         CaseLet<Enum, Case2, Content2>,
@@ -748,7 +748,7 @@ extension Switch {
     DefaultContent
   >(
     _ enum: Binding<Enum>,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<Enum, Case1, Content1>,
         CaseLet<Enum, Case2, Content2>,
@@ -827,7 +827,7 @@ extension Switch {
     _ enum: Binding<Enum>,
     file: StaticString = #fileID,
     line: UInt = #line,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<Enum, Case1, Content1>,
         CaseLet<Enum, Case2, Content2>,
@@ -894,7 +894,7 @@ extension Switch {
     DefaultContent
   >(
     _ enum: Binding<Enum>,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<Enum, Case1, Content1>,
         CaseLet<Enum, Case2, Content2>,
@@ -980,7 +980,7 @@ extension Switch {
     _ enum: Binding<Enum>,
     file: StaticString = #fileID,
     line: UInt = #line,
-    @ViewBuilder content: @escaping () -> TupleView<
+    @ViewBuilder content: () -> TupleView<
       (
         CaseLet<Enum, Case1, Content1>,
         CaseLet<Enum, Case2, Content2>,

--- a/SwiftUINavigation.xcworkspace/contents.xcworkspacedata
+++ b/SwiftUINavigation.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:">
    </FileRef>
+   <FileRef
+      location = "group:Examples/Examples.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/SwiftUINavigation.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SwiftUINavigation.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -9,6 +9,24 @@
           "revision": "7346701ea29da0a85d4403cf3d7a589a58ae3dee",
           "version": "0.9.2"
         }
+      },
+      {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections",
+        "state": {
+          "branch": null,
+          "revision": "f504716c27d2e5d4144fa4794b12129301d17729",
+          "version": "1.0.3"
+        }
+      },
+      {
+        "package": "swift-identified-collections",
+        "repositoryURL": "https://github.com/pointfreeco/swift-identified-collections.git",
+        "state": {
+          "branch": null,
+          "revision": "bfb0d43e75a15b6dfac770bf33479e8393884a36",
+          "version": "0.4.1"
+        }
       }
     ]
   },


### PR DESCRIPTION
A couple updates:

- Modernize older `NavigationLink` APIs (and deprecate for iOS 16+)
- Make a bunch of escaping closures non-escaping