### PR TITLE
Exclude `id` from ButtonState's equatable conformance

### DIFF
--- a/Sources/_SwiftUINavigationState/ButtonState.swift
+++ b/Sources/_SwiftUINavigationState/ButtonState.swift
@@ -137,7 +137,13 @@ extension ButtonState.Handler: CustomDumpReflectable {
 extension ButtonState.Handler: Equatable where Action: Equatable {}
 extension ButtonState.Handler._ActionType: Equatable where Action: Equatable {}
 extension ButtonState.Role: Equatable {}
-extension ButtonState: Equatable where Action: Equatable {}
+extension ButtonState: Equatable where Action: Equatable {
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.action == rhs.action
+      && lhs.label == rhs.label
+      && lhs.role == rhs.role
+  }
+}
 
 extension ButtonState.Handler: Hashable where Action: Hashable {}
 extension ButtonState.Handler._ActionType: Hashable where Action: Hashable {

--- a/Tests/SwiftUINavigationTests/AlertTests.swift
+++ b/Tests/SwiftUINavigationTests/AlertTests.swift
@@ -4,16 +4,24 @@ import XCTest
 
 final class AlertTests: XCTestCase {
   func testAlertState() {
-    var dump = ""
-    customDump(
+    let alert = AlertState(
+      title: .init("Alert!"),
+      message: .init("Something went wrong..."),
+      primaryButton: .destructive(.init("Destroy"), action: .send(true, animation: .default)),
+      secondaryButton: .cancel(.init("Cancel"), action: .send(false))
+    )
+    XCTAssertNoDifference(
+      alert,
       AlertState(
         title: .init("Alert!"),
         message: .init("Something went wrong..."),
         primaryButton: .destructive(.init("Destroy"), action: .send(true, animation: .default)),
         secondaryButton: .cancel(.init("Cancel"), action: .send(false))
-      ),
-      to: &dump
+      )
     )
+    
+    var dump = ""
+    customDump(alert, to: &dump)
     XCTAssertNoDifference(
       dump,
       """


### PR DESCRIPTION
How about excluding `id` in the `Equatable` implementation for `ButtonState` as well as `AlertState`?

Fixes https://github.com/pointfreeco/swift-composable-architecture/issues/1687