### PR TITLE
Adds custom Equatable implementation for ButtonState

### DIFF
--- a/Sources/_SwiftUINavigationState/ButtonState.swift
+++ b/Sources/_SwiftUINavigationState/ButtonState.swift
@@ -137,7 +137,13 @@ extension ButtonState.Handler: CustomDumpReflectable {
 extension ButtonState.Handler: Equatable where Action: Equatable {}
 extension ButtonState.Handler._ActionType: Equatable where Action: Equatable {}
 extension ButtonState.Role: Equatable {}
-extension ButtonState: Equatable where Action: Equatable {}
+extension ButtonState: Equatable where Action: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.action == rhs.action
+          && lhs.label == rhs.label
+          && lhs.role == rhs.role
+      }
+}
 
 extension ButtonState.Handler: Hashable where Action: Hashable {}
 extension ButtonState.Handler._ActionType: Hashable where Action: Hashable {


### PR DESCRIPTION
The new ButtonState has an id with default UUID() value which breaks test in a TCA application. ("// Not equal but no difference detected:"). The custom equality check ignores the id