### PR TITLE
Remove `id` from `ButtonState` and `AlertState`

### DIFF
--- a/Sources/SwiftUINavigation/Alert.swift
+++ b/Sources/SwiftUINavigation/Alert.swift
@@ -169,8 +169,8 @@ extension View {
         isPresented: value.isPresent(),
         presenting: value.wrappedValue,
         actions: {
-          ForEach($0.buttons) {
-            Button($0, action: action)
+          ForEach(Array(zip(0..., $0.buttons)), id: \.0) {
+            Button($0.1, action: action)
           }
         },
         message: { $0.message.map { Text($0) } }
@@ -186,8 +186,8 @@ extension View {
         isPresented: value.isPresent(),
         presenting: value.wrappedValue,
         actions: {
-          ForEach($0.buttons) {
-            Button($0, action: { (_: Never) in fatalError() })
+          ForEach(Array(zip(0..., $0.buttons)), id: \.0) {
+            Button($0.1, action: { (_: Never) in fatalError() })
           }
         },
         message: { $0.message.map { Text($0) } }

--- a/Sources/SwiftUINavigation/Alert.swift
+++ b/Sources/SwiftUINavigation/Alert.swift
@@ -125,8 +125,8 @@ extension View {
         isPresented: value.isPresent(),
         presenting: value.wrappedValue,
         actions: {
-          ForEach(Array(zip(0..., $0.buttons)), id: \.0) { _, button in
-            Button(button, action: action)
+          ForEach(Array(zip(0..., $0.buttons)), id: \.0) {
+            Button($0.1, action: action)
           }
         },
         message: { $0.message.map { Text($0) } }

--- a/Sources/SwiftUINavigation/Alert.swift
+++ b/Sources/SwiftUINavigation/Alert.swift
@@ -125,8 +125,8 @@ extension View {
         isPresented: value.isPresent(),
         presenting: value.wrappedValue,
         actions: {
-          ForEach($0.buttons) {
-            Button($0, action: action)
+          ForEach(Array(zip(0..., $0.buttons)), id: \.0) { _, button in
+            Button(button, action: action)
           }
         },
         message: { $0.message.map { Text($0) } }

--- a/Sources/SwiftUINavigation/ConfirmationDialog.swift
+++ b/Sources/SwiftUINavigation/ConfirmationDialog.swift
@@ -180,8 +180,8 @@ extension View {
         titleVisibility: value.wrappedValue.map { .init($0.titleVisibility) } ?? .automatic,
         presenting: value.wrappedValue,
         actions: {
-          ForEach($0.buttons) {
-            Button($0, action: action)
+          ForEach(Array(zip(0..., $0.buttons)), id: \.0) {
+            Button($0.1, action: action)
           }
         },
         message: { $0.message.map { Text($0) } }

--- a/Sources/SwiftUINavigation/ConfirmationDialog.swift
+++ b/Sources/SwiftUINavigation/ConfirmationDialog.swift
@@ -134,8 +134,8 @@ extension View {
         titleVisibility: value.wrappedValue.map { .init($0.titleVisibility) } ?? .automatic,
         presenting: value.wrappedValue,
         actions: {
-          ForEach(Array(zip(0..., $0.buttons)), id: \.0) { _, button in
-            Button(button, action: action)
+          ForEach(Array(zip(0..., $0.buttons)), id: \.0) {
+            Button($0.1, action: action)
           }
         },
         message: { $0.message.map { Text($0) } }

--- a/Sources/SwiftUINavigation/ConfirmationDialog.swift
+++ b/Sources/SwiftUINavigation/ConfirmationDialog.swift
@@ -134,8 +134,8 @@ extension View {
         titleVisibility: value.wrappedValue.map { .init($0.titleVisibility) } ?? .automatic,
         presenting: value.wrappedValue,
         actions: {
-          ForEach($0.buttons) {
-            Button($0, action: action)
+          ForEach(Array(zip(0..., $0.buttons)), id: \.0) { _, button in
+            Button(button, action: action)
           }
         },
         message: { $0.message.map { Text($0) } }

--- a/Sources/_SwiftUINavigationState/AlertState.swift
+++ b/Sources/_SwiftUINavigationState/AlertState.swift
@@ -126,8 +126,7 @@ import SwiftUI
 /// }
 /// model.alert = nil
 /// ```
-public struct AlertState<Action>: Identifiable {
-  public let id = UUID()
+public struct AlertState<Action> {
   public var buttons: [ButtonState<Action>]
   public var message: TextState?
   public var title: TextState

--- a/Sources/_SwiftUINavigationState/ButtonState.swift
+++ b/Sources/_SwiftUINavigationState/ButtonState.swift
@@ -1,7 +1,7 @@
 import CustomDump
 import SwiftUI
 
-public struct ButtonState<Action>: Identifiable {
+public struct ButtonState<Action> {
   /// A type that wraps an action with additional context, _e.g._ for animation.
   public struct Handler {
     public let type: _ActionType
@@ -35,7 +35,6 @@ public struct ButtonState<Action>: Identifiable {
     case destructive
   }
 
-  public let id = UUID()
   public let action: Handler?
   public let label: TextState
   public let role: Role?
@@ -137,13 +136,7 @@ extension ButtonState.Handler: CustomDumpReflectable {
 extension ButtonState.Handler: Equatable where Action: Equatable {}
 extension ButtonState.Handler._ActionType: Equatable where Action: Equatable {}
 extension ButtonState.Role: Equatable {}
-extension ButtonState: Equatable where Action: Equatable {
-  public static func == (lhs: Self, rhs: Self) -> Bool {
-    lhs.action == rhs.action
-      && lhs.label == rhs.label
-      && lhs.role == rhs.role
-  }
-}
+extension ButtonState: Equatable where Action: Equatable {}
 
 extension ButtonState.Handler: Hashable where Action: Hashable {}
 extension ButtonState.Handler._ActionType: Hashable where Action: Hashable {
@@ -155,13 +148,7 @@ extension ButtonState.Handler._ActionType: Hashable where Action: Hashable {
   }
 }
 extension ButtonState.Role: Hashable {}
-extension ButtonState: Hashable where Action: Hashable {
-  public func hash(into hasher: inout Hasher) {
-    hasher.combine(self.action)
-    hasher.combine(self.label)
-    hasher.combine(self.role)
-  }
-}
+extension ButtonState: Hashable where Action: Hashable {}
 
 // MARK: - SwiftUI bridging
 


### PR DESCRIPTION
If I'm not mistaken, `Identifiable` is only used to simplify `ForEach` iteration in the `actions`.

This PR removes the uncontrolled `Identifiable` conformance for `ButtonState` and `AlertState`. The button's array is indexed before iterating over it, and theses indices are used as unique identifiers. Because of the nature of `Alert` and `Confirmation` dialog, this likely won't have unexpected side-effects. We could probably use `enumerated()` instead of `zip` here and I can update the PR if you want.

It also restores automatic `Equatable` and `Hashable` conformance for `ButtonState`. In my experience, using a partial `Equatable` conformance inevitably lead to incoherent situations and invariants being broken in the long run.

Please let me know if I'm missing something and `Identifiable` is used in other places than these loops.