### PR TITLE
[CaseStudies] Make `confirmationDialog` as a popover fully visible on iPad

### DIFF
--- a/Examples/CaseStudies/02-ConfirmationDialogs.swift
+++ b/Examples/CaseStudies/02-ConfirmationDialogs.swift
@@ -18,18 +18,18 @@ struct OptionalConfirmationDialogs: View {
         }
       }
       .disabled(self.model.isLoading)
+      .confirmationDialog(
+        title: { Text("Fact about \($0.number)") },
+        titleVisibility: .visible,
+        unwrapping: self.$model.fact,
+        actions: {
+          Button("Get another fact about \($0.number)") {
+            self.model.numberFactButtonTapped()
+          }
+        },
+        message: { Text($0.description) }
+      )
     }
-    .confirmationDialog(
-      title: { Text("Fact about \($0.number)") },
-      titleVisibility: .visible,
-      unwrapping: self.$model.fact,
-      actions: {
-        Button("Get another fact about \($0.number)") {
-          self.model.numberFactButtonTapped()
-        }
-      },
-      message: { Text($0.description) }
-    )
     .navigationTitle("Dialogs")
   }
 }


### PR DESCRIPTION
There was an issue that the `confirmationDialog` (rendered as a "popover") was not fully visible on `iPad` screen.
I changed where the `confirmationDialog` modifier applied so that the "popover" is visible on `iPad`.

<br>

<img width="1068" alt="confirmationDialog fix" src="https://user-images.githubusercontent.com/71127966/203479043-dd370ccc-2685-4f2c-8352-db797a89974a.png">
