### PR TITLE
Directly modify the view in `bind` instead of relying on a `ViewModifier`

### DIFF
--- a/Sources/SwiftUINavigation/Bind.swift
+++ b/Sources/SwiftUINavigation/Bind.swift
@@ -20,36 +20,25 @@ extension View {
     _ modelValue: ModelValue, to viewValue: ViewValue
   ) -> some View
   where ModelValue.Value == ViewValue.Value, ModelValue.Value: Equatable {
-    self.modifier(_Bind(modelValue: modelValue, viewValue: viewValue))
-  }
-}
-
-@available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
-private struct _Bind<ModelValue: _Bindable, ViewValue: _Bindable>: ViewModifier
-where ModelValue.Value == ViewValue.Value, ModelValue.Value: Equatable {
-  let modelValue: ModelValue
-  let viewValue: ViewValue
-
-  @State var hasAppeared = false
-
-  func body(content: Content) -> some View {
-    content
-      .onAppear {
-        guard !self.hasAppeared else { return }
-        self.hasAppeared = true
-        guard self.viewValue.wrappedValue != self.modelValue.wrappedValue else { return }
-        self.viewValue.wrappedValue = self.modelValue.wrappedValue
-      }
-      .onChange(of: self.modelValue.wrappedValue) {
-        guard self.viewValue.wrappedValue != $0
-        else { return }
-        self.viewValue.wrappedValue = $0
-      }
-      .onChange(of: self.viewValue.wrappedValue) {
-        guard self.modelValue.wrappedValue != $0
-        else { return }
-        self.modelValue.wrappedValue = $0
-      }
+    WithState(initialValue: false) { $hasAppeared in
+      self
+        .onAppear {
+          guard !hasAppeared else { return }
+          hasAppeared = true
+          guard viewValue.wrappedValue != modelValue.wrappedValue else { return }
+          viewValue.wrappedValue = modelValue.wrappedValue
+        }
+        .onChange(of: modelValue.wrappedValue) {
+          guard viewValue.wrappedValue != $0
+          else { return }
+          viewValue.wrappedValue = $0
+        }
+        .onChange(of: viewValue.wrappedValue) {
+          guard modelValue.wrappedValue != $0
+          else { return }
+          modelValue.wrappedValue = $0
+        }
+    }
   }
 }
 


### PR DESCRIPTION
This seems to fix #44.
For some reason, it doesn't works with a wrapper view `_Bind<ModelValue: _Bindable, ViewValue: _Bindable, Content: View>: View`. 
I initially thought that the escaping closure of `WithState` was providing enough invalidation to make the changes effective, but it also works if one removes `WithState` (and the `hasAppeared` logic), so I don't really know what's happening here. Maybe the stored `Bindable` are interfering with SwiftUI's diffing algorithm and are not properly observed/handled.
This PR is mostly there to serve as a basis for discussion, as many things are still nebulous.