### PR TITLE
Remove `_Bindable` `DynamicProperty` inheritance.

### DIFF
--- a/Sources/SwiftUINavigation/Bind.swift
+++ b/Sources/SwiftUINavigation/Bind.swift
@@ -53,7 +53,7 @@ where ModelValue.Value == ViewValue.Value, ModelValue.Value: Equatable {
   }
 }
 
-public protocol _Bindable: DynamicProperty {
+public protocol _Bindable {
   associatedtype Value
   var wrappedValue: Value { get nonmutating set }
 }


### PR DESCRIPTION
This also seems to fix #44.
I suppose that `_Bindable` being a `DynamicProperty` is somehow interfering with SwiftUI's observation.
As all conforming types are already `DynamicProperty`, and all uses of `_Bindable` always generic, we shouldn't lose anything at all by removing this inheritance.
I'm closing #45 in favor of this PR.