### PR TITLE
Fix action in `Alert.Button.init` not to be `nil`

### DIFF
--- a/Sources/_SwiftUINavigationState/ButtonState.swift
+++ b/Sources/_SwiftUINavigationState/ButtonState.swift
@@ -167,7 +167,7 @@ extension ButtonState: Hashable where Action: Hashable {
 
 extension Alert.Button {
   public init<Action>(_ button: ButtonState<Action>, action: @escaping (Action) -> Void) {
-    let action = button.action.map { _ in { button.withAction(action) } }
+    let action = { button.withAction(action) }
     switch button.role {
     case .cancel:
       self = .cancel(Text(button.label), action: action)


### PR DESCRIPTION
I think `action` in `Alert.Button.init<Action>(_ button: ButtonState<Action>, action: @escaping (Action) -> Void)` should not be `nil` to make the behavior as before on iOS 14 or as the behavior on iOS 15 later (= Not to be disabled dismiss button when not setting dismiss action). 

Fixes https://github.com/pointfreeco/swift-composable-architecture/issues/1741