### PR TITLE
Allow `Binding<Case?>` to write into `nil`

### DIFF
--- a/Sources/SwiftUINavigation/Binding.swift
+++ b/Sources/SwiftUINavigation/Binding.swift
@@ -59,7 +59,6 @@ extension Binding {
     .init(
       get: { self.wrappedValue.flatMap(casePath.extract(from:)) },
       set: { newValue, transaction in
-        guard self.wrappedValue != nil else { return }
         self.transaction(transaction).wrappedValue = newValue.map(casePath.embed)
       }
     )


### PR DESCRIPTION
We recently prevented `Binding.init?(unwrapping:case:)` from changing the case, which makes sense because it's a failable initializer and we don't want ghost bindings to be able to write back into the system once the value goes `nil`. This includes a SwiftUI bug where text fields that are focused during dismissal can write into the binding, effectively un-dismissing the binding.

I think we applied the same logic to `Binding.case`, though, but I do _not_ think that's what we want to do, and it actually caused a regression.

Fixes #53.