### PR TITLE
Allow Binding<Case?> to write into nil or when the case matches

### DIFF
--- a/Sources/SwiftUINavigation/Binding.swift
+++ b/Sources/SwiftUINavigation/Binding.swift
@@ -59,6 +59,7 @@ extension Binding {
     .init(
       get: { self.wrappedValue.flatMap(casePath.extract(from:)) },
       set: { newValue, transaction in
+        guard self.wrappedValue == nil || casePath ~= self.wrappedValue! else { return }
         self.transaction(transaction).wrappedValue = newValue.map(casePath.embed)
       }
     )


### PR DESCRIPTION
Allowing `Binding.case` to always be writable may result in unwanted behaviour. If a binding changes case, it may be subsequently set to `nil` after the previous case is dismissed. Writing when the enum is `nil` or when the case matches could be a solution. I'm unsure if this is a common use case or if this change introduces some other unwanted behaviour. I just noticed a difference while replacing some customer helpers. 

An example:

  ```swift
  struct ContentView: View {
    @State var route: Route?

    enum Route { case foo, bar }

    var body: some View {
      VStack {
        Button("Show Foo") { self.route = .foo }
      }
      .confirmationDialog(
        title: { Text("Foo") },
        unwrapping: self.$route.case(/Route.foo),
        actions: { Button("Show Bar") { self.route = .bar } },
        message: { Text("Foo") }
      )
      .sheet(unwrapping: self.$route.case(/Route.bar)) { _ in
        Text("Bar")
      }
    }
  }
```

