### PR TITLE
Fix a code typo in DestructuringViews article

### DIFF
--- a/Sources/SwiftUINavigation/Documentation.docc/Articles/DestructuringViews.md
+++ b/Sources/SwiftUINavigation/Documentation.docc/Articles/DestructuringViews.md
@@ -104,7 +104,7 @@ struct EditView: View {
       } else: {
         Text("\(self.string)")
         Button("Edit") {
-          self.editableString = self.string
+          self.editableString = .active(self.string)
         }
       }
       .buttonStyle(.borderless)


### PR DESCRIPTION
### Fix in `IfCaseLet` section
`self.string` → `.active(self.string)`