### PR TITLE
Alert/ConfirmationDialog updates

### DIFF
--- a/Examples/Inventory/ItemRow.swift
+++ b/Examples/Inventory/ItemRow.swift
@@ -113,9 +113,10 @@ struct ItemRowView: View {
       .foregroundColor(self.model.item.status.isInStock ? nil : Color.gray)
       .alert(
         unwrapping: self.$model.destination,
-        case: /ItemRowModel.Destination.alert,
-        action: self.model.alertButtonTapped
-      )
+        case: /ItemRowModel.Destination.alert
+      ) {
+        self.model.alertButtonTapped($0)
+      }
       .popover(
         unwrapping: self.$model.destination,
         case: /ItemRowModel.Destination.duplicate

--- a/Sources/SwiftUINavigation/Alert.swift
+++ b/Sources/SwiftUINavigation/Alert.swift
@@ -113,7 +113,7 @@ extension View {
     ///     populate the fields of an alert that the system displays to the user. When the user
     ///     presses or taps one of the alert's actions, the system sets this value to `nil` and
     ///     dismisses the alert, and the action is fed to the `action` closure.
-    ///   - action: A closure that is called with an action from a particular alert button when
+    ///   - handler: A closure that is called with an action from a particular alert button when
     ///     tapped.
     @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
     public func alert<Value>(
@@ -152,15 +152,15 @@ extension View {
     ///     When the user presses or taps one of the alert's actions, the system sets this value to
     ///     `nil` and dismisses the alert, and the action is fed to the `action` closure.
     ///   - casePath: A case path that identifies a particular case that holds alert state.
-    ///   - action: A closure that is called with an action from a particular alert button when
+    ///   - handler: A closure that is called with an action from a particular alert button when
     ///     tapped.
     @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
     public func alert<Enum, Value>(
       unwrapping `enum`: Binding<Enum?>,
       case casePath: CasePath<Enum, AlertState<Value>>,
-      action: @escaping (Value) async -> Void = { (_: Void) async in }
+      action handler: @escaping (Value) async -> Void = { (_: Void) async in }
     ) -> some View {
-      self.alert(unwrapping: `enum`.case(casePath), action: action)
+      self.alert(unwrapping: `enum`.case(casePath), action: handler)
     }
   #else
     @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
@@ -206,9 +206,9 @@ extension View {
     public func alert<Enum, Value>(
       unwrapping `enum`: Binding<Enum?>,
       case casePath: CasePath<Enum, AlertState<Value>>,
-      action: @escaping (Value) async -> Void
+      action handler: @escaping (Value) async -> Void
     ) -> some View {
-      self.alert(unwrapping: `enum`.case(casePath), action: action)
+      self.alert(unwrapping: `enum`.case(casePath), action: handler)
     }
 
     @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)

--- a/Sources/SwiftUINavigation/Documentation.docc/Articles/AlertsDialogs.md
+++ b/Sources/SwiftUINavigation/Documentation.docc/Articles/AlertsDialogs.md
@@ -78,10 +78,9 @@ struct ContentView: View {
     List {
       // ...
     }
-    .alert(
-      unwrapping: self.$model.alert,
-      action: self.alertButtonTapped
-    )
+    .alert(unwrapping: self.$model.alert) { action in
+      self.model.alertButtonTapped(action)
+    }
   }
 }
 ```
@@ -129,11 +128,9 @@ With this kind of set up you can use an alternative `alert` view modifier that t
 argument for specifying which case of the enum drives the presentation of the alert:
 
 ```swift
-.alert(
-  unwrapping: self.$model.destination,
-  case: /Destination.alert,
-  action: self.alertButtonTapped
-)
+.alert(unwrapping: self.$model.destination, case: /Destination.alert) { action in
+  self.model.alertButtonTapped(action)
+}
 ```
 
 Note that the `case` argument is specified via a concept known as "case paths", which are like
@@ -185,10 +182,9 @@ struct ContentView: View {
     List {
       // ...
     }
-    .confirmationDialog(
-      unwrapping: self.$model.dialog,
-      action: self.dialogButtonTapped
-    )
+    .confirmationDialog(unwrapping: self.$model.dialog) { action in
+      self.dialogButtonTapped(action)
+    }
   }
 }
 ```


### PR DESCRIPTION
- Add support for `async` confirmation dialog actions (we added them to alerts back in #61).
- Update docs/examples to avoid using point-free style for these action handlers (which can lead to things running on the wrong actor).