### PR TITLE
Real dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,6 +32,7 @@ let package = Package(
       dependencies: [
         .product(name: "CasePaths", package: "swift-case-paths"),
         .product(name: "CustomDump", package: "swift-custom-dump"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
       ]
     ),
     .target(
@@ -40,7 +41,6 @@ let package = Package(
         "_SwiftUINavigationState",
         .product(name: "CasePaths", package: "swift-case-paths"),
         .product(name: "CustomDump", package: "swift-custom-dump"),
-        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
       ]
     ),
     .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,6 @@ let package = Package(
     .target(
       name: "_SwiftUINavigationState",
       dependencies: [
-        .product(name: "CasePaths", package: "swift-case-paths"),
         .product(name: "CustomDump", package: "swift-custom-dump"),
         .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
       ]
@@ -40,7 +39,6 @@ let package = Package(
       dependencies: [
         "_SwiftUINavigationState",
         .product(name: "CasePaths", package: "swift-case-paths"),
-        .product(name: "CustomDump", package: "swift-custom-dump"),
       ]
     ),
     .testTarget(


### PR DESCRIPTION
As I was trying to find the smallest reproduction of the problem mentioned in https://github.com/pointfreeco/swift-composable-architecture/discussions/1774 to report it to Apple, I got linking errors when building `_SwiftUINavigationState`. It was missing symbols from XCTestDynamicOverlay.

Looking at this project's Package.swift and source code, it seems the dependencies declaration in Package.swift and the uses in the code do not match (even though the project builds successfully in most cases).

The problem is that even though _SwiftUINavigationState is using XCTestDynamicOverlay, only SwiftUINavigation is depending on it.

As I was looking in more details, it seems CustomDump was only used from _SwiftUINavigationState, and CasePaths only from SwiftUINavigation so I removed them from the unused target. However having an unused dependency won't cause any problem and you might want add them back later so if you prefer I can remove that part of the change from my PR.