### PR TITLE
Fix mismatched words in Routing case study

### DIFF
--- a/Examples/CaseStudies/09-Routing.swift
+++ b/Examples/CaseStudies/09-Routing.swift
@@ -5,7 +5,7 @@ private let readMe = """
   This case study demonstrates how to power multiple forms of navigation from a single destination \
   enum that describes all of the possible destinations one can travel to from this screen.
 
-  The screen has three navigation destinations: an alert, a navigation link to a count stepper, \
+  The screen has four navigation destinations: an alert, a confirmation dialog, a navigation link to a count stepper, \
   and a modal sheet to a count stepper. The state for each of these destinations is held as \
   associated data of an enum, and bindings to the cases of that enum are derived using the tools \
   in this library.
@@ -77,7 +77,7 @@ struct Routing: View {
         }
       } destination: { $count in
         Form {
-          Stepper("Number: \(count)", value: $count)
+          Stepper("Count: \(count)", value: $count)
         }
         .navigationTitle("Routing link")
       } label: {
@@ -115,7 +115,7 @@ struct Routing: View {
     .sheet(unwrapping: self.$destination, case: /Destination.sheet) { $count in
       NavigationView {
         Form {
-          Stepper("Number: \(count)", value: $count)
+          Stepper("Count: \(count)", value: $count)
         }
         .navigationTitle("Routing sheet")
       }


### PR DESCRIPTION
Hi, I caught some mismatched words in `09-Routing` case study.
- There are `four` destinations in the 'enum Destination', not three.
- Changed word: "Number" → `"Count"` for consistency.

Btw, the Count state value cannot be changed in both NavigationLink and Sheet.
Is this kind of intended behavior, or is it an error?

https://user-images.githubusercontent.com/71127966/216416129-0cde6ce9-16e9-4381-aa0b-2411fdbc3813.mov


