### PR TITLE
fix minor typo in Navigation.md documentation

### DIFF
--- a/Sources/SwiftUINavigation/Documentation.docc/Articles/Navigation.md
+++ b/Sources/SwiftUINavigation/Documentation.docc/Articles/Navigation.md
@@ -105,7 +105,7 @@ Button {
 .navigationDestination(
   unwrapping: self.$model.destination,
   case: /Destination.counter
-) { $item in 
+) { $number in 
   CounterView(number: $number)
 }
 ```


### PR DESCRIPTION
I was reading through documentation and noticed a minor typo in the example. There is a mismatch between $item and $number. Since the above example uses $number, I changed $item to $number.