### PR TITLE
Scope `navigationDestination` bind workaround

### DIFF
--- a/Sources/SwiftUINavigation/NavigationDestination.swift
+++ b/Sources/SwiftUINavigation/NavigationDestination.swift
@@ -1,4 +1,4 @@
-#if swift(>=5.7) && (os(iOS) || os(macOS) || os(tvOS) || os(watchOS))
+#if swift(>=5.7)
   import SwiftUI
 
   @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)

--- a/Sources/SwiftUINavigation/NavigationDestination.swift
+++ b/Sources/SwiftUINavigation/NavigationDestination.swift
@@ -99,17 +99,9 @@
     }
   }
 
-  #if os(iOS) || os(tvOS)
-    private let requiresBindWorkaround = !ProcessInfo.processInfo.isOperatingSystemAtLeast(
-      OperatingSystemVersion(majorVersion: 16, minorVersion: 4, patchVersion: 0)
-    )
-  #elseif os(macOS)
-    private let requiresBindWorkaround = !ProcessInfo.processInfo.isOperatingSystemAtLeast(
-      OperatingSystemVersion(majorVersion: 13, minorVersion: 3, patchVersion: 0)
-    )
-  #elseif os(watchOS)
-    private let requiresBindWorkaround = !ProcessInfo.processInfo.isOperatingSystemAtLeast(
-      OperatingSystemVersion(majorVersion: 9, minorVersion: 4, patchVersion: 0)
-    )
-  #endif
+  private let requiresBindWorkaround = {
+    guard #available(iOS 16.4, macOS 13.3, tvOS 16.4, watchOS 9.4, *)
+    else { return true }
+    return false
+  }()
 #endif


### PR DESCRIPTION
A lot of `SwiftUI.navigationDestination` bugs have been fixed in the betas such that our library-level fixes cause problems. So let's scope those fixes to past versions.