### PR TITLE
Fix MainActor with defer compile error

### DIFF
--- a/Examples/CaseStudies/01-Alerts.swift
+++ b/Examples/CaseStudies/01-Alerts.swift
@@ -45,8 +45,8 @@ private class FeatureModel: ObservableObject {
   func numberFactButtonTapped() {
     Task {
       self.isLoading = true
-      defer { self.isLoading = false }
       self.fact = await getNumberFact(self.count)
+      self.isLoading = false
     }
   }
 }

--- a/Examples/CaseStudies/02-ConfirmationDialogs.swift
+++ b/Examples/CaseStudies/02-ConfirmationDialogs.swift
@@ -43,8 +43,8 @@ private class FeatureModel: ObservableObject {
   func numberFactButtonTapped() {
     Task {
       self.isLoading = true
-      defer { self.isLoading = false }
       self.fact = await getNumberFact(self.count)
+      self.isLoading = false
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ it's as simple as adding it to a `dependencies` clause in your `Package.swift`:
 
 ``` swift
 dependencies: [
-  .package(url: "https://github.com/pointfreeco/swiftui-navigation", from: "0.4.5")
+  .package(url: "https://github.com/pointfreeco/swiftui-navigation", from: "0.7.1")
 ]
 ```
 


### PR DESCRIPTION
Hi, I ran into two compile errors in CaseStudies.
Stephen fixed some MainActor warnings in #89, but `defer` with MainActor caused compile error.

<img width="755" alt="compile error in Task" src="https://user-images.githubusercontent.com/71127966/226409958-655d7d78-12cb-4d51-87bb-ca61a40355ac.png">

I removed `defer` to make it work for now, but if you have any other solutions, please comment. 😄 