### PR TITLE
Import Foundation in RuntimeWarnings for String CVarArgs conformance

### DIFF
--- a/Sources/_SwiftUINavigationState/Internal/RuntimeWarnings.swift
+++ b/Sources/_SwiftUINavigationState/Internal/RuntimeWarnings.swift
@@ -37,6 +37,7 @@ public func runtimeWarn(
 
   #if canImport(os)
     import os
+    import Foundation
 
     // NB: Xcode runtime warnings offer a much better experience than traditional assertions and
     //     breakpoints, but Apple provides no means of creating custom runtime warnings ourselves.


### PR DESCRIPTION
New warning with Xcode 14.3 about not having access to Swift.String's CVarArgs conformance without the Foundation import.
