### PR TITLE
Import Foundation to suppress warning

### DIFF
--- a/Sources/_SwiftUINavigationState/Internal/RuntimeWarnings.swift
+++ b/Sources/_SwiftUINavigationState/Internal/RuntimeWarnings.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 @_spi(RuntimeWarn)
 @_transparent
 @inline(__always)


### PR DESCRIPTION
I'm seeing this warning in my project in Xcode 14.3.1RC. I don't see it when I build the swiftui-navigation project, though, which is weird. But this should fix it.

<img width="1057" alt="screenshot of Xcode showing a warning on a string being passed to the os_log function: Cannot use conformance of 'String' to 'CVarArg' here; 'Foundation' was not imported by this file; this is an error in Swift 6" src="https://github.com/pointfreeco/swiftui-navigation/assets/464574/03d0bb0f-459f-439e-b8b0-488f4a727db4">
