### PR TITLE
Add `Sendable` conformances

### DIFF
--- a/Sources/SwiftUINavigationCore/ButtonState.swift
+++ b/Sources/SwiftUINavigationCore/ButtonState.swift
@@ -227,6 +227,15 @@ extension ButtonState: Hashable where Action: Hashable {
   }
 }
 
+// MARK: - Sendable Annotations
+
+#if swift(>=5.9)
+extension ButtonStateAction: Sendable where Action: Sendable {}
+extension ButtonStateAction._ActionType: Sendable where Action: Sendable {}
+extension ButtonStateRole: Sendable {}
+extension ButtonState: Sendable where Action: Sendable {}
+#endif
+
 // MARK: - SwiftUI bridging
 
 extension Alert.Button {

--- a/Sources/SwiftUINavigationCore/ButtonState.swift
+++ b/Sources/SwiftUINavigationCore/ButtonState.swift
@@ -147,7 +147,7 @@ public struct ButtonStateAction<Action> {
 /// A value that describes the purpose of a button.
 ///
 /// See `SwiftUI.ButtonRole` for more information.
-public enum ButtonStateRole {
+public enum ButtonStateRole: Sendable {
   /// A role that indicates a cancel button.
   ///
   /// See `SwiftUI.ButtonRole.cancel` for more information.
@@ -227,12 +227,9 @@ extension ButtonState: Hashable where Action: Hashable {
   }
 }
 
-// MARK: - Sendable Annotations
-
-#if swift(>=5.9)
+#if swift(>=5.7)
 extension ButtonStateAction: Sendable where Action: Sendable {}
 extension ButtonStateAction._ActionType: Sendable where Action: Sendable {}
-extension ButtonStateRole: Sendable {}
 extension ButtonState: Sendable where Action: Sendable {}
 #endif
 

--- a/Sources/SwiftUINavigationCore/ConfirmationDialogState.swift
+++ b/Sources/SwiftUINavigationCore/ConfirmationDialogState.swift
@@ -265,9 +265,7 @@ extension ConfirmationDialogState: Hashable where Action: Hashable {
   }
 }
 
-// MARK: - Sendable Annotations
-
-#if swift(>=5.9)
+#if swift(>=5.7)
 @available(iOS 13, *)
 @available(macOS 12, *)
 @available(tvOS 13, *)

--- a/Sources/SwiftUINavigationCore/ConfirmationDialogState.swift
+++ b/Sources/SwiftUINavigationCore/ConfirmationDialogState.swift
@@ -199,7 +199,7 @@ public struct ConfirmationDialogState<Action>: Identifiable {
 /// platform, current context, and other factors.
 ///
 /// See `SwiftUI.Visibility` for more information.
-public enum ConfirmationDialogStateTitleVisibility {
+public enum ConfirmationDialogStateTitleVisibility: Sendable {
   /// The element may be visible or hidden depending on the policies of the component accepting the
   /// visibility configuration.
   ///
@@ -264,6 +264,16 @@ extension ConfirmationDialogState: Hashable where Action: Hashable {
     hasher.combine(self.buttons)
   }
 }
+
+// MARK: - Sendable Annotations
+
+#if swift(>=5.9)
+@available(iOS 13, *)
+@available(macOS 12, *)
+@available(tvOS 13, *)
+@available(watchOS 6, *)
+extension ConfirmationDialogState: Sendable where Action: Sendable {}
+#endif
 
 // MARK: - SwiftUI bridging
 

--- a/Sources/SwiftUINavigationCore/TextState.swift
+++ b/Sources/SwiftUINavigationCore/TextState.swift
@@ -739,3 +739,14 @@ extension TextState: CustomDumpRepresentable {
     return dumpHelp(self)
   }
 }
+
+// MARK: - Sendable Annotations
+
+#if swift(>=5.9)
+extension TextState: Sendable {}
+extension TextState.AccessibilityHeadingLevel: Sendable {}
+extension TextState.AccessibilityTextContentType: Sendable {}
+extension TextState.FontWidth: Sendable {}
+extension TextState.LineStylePattern: Sendable {}
+extension TextState.Modifier: Sendable {}
+#endif

--- a/Sources/SwiftUINavigationCore/TextState.swift
+++ b/Sources/SwiftUINavigationCore/TextState.swift
@@ -43,11 +43,11 @@ import SwiftUI
 /// - Note: ``TextState`` does not support _all_ `LocalizedStringKey` permutations at this time
 ///   (interpolated `SwiftUI.Image`s, for example). ``TextState`` also uses reflection to determine
 ///   `LocalizedStringKey` equatability, so be mindful of edge cases.
-public struct TextState: Equatable, Hashable {
+public struct TextState: Equatable, Hashable, Sendable {
   fileprivate var modifiers: [Modifier] = []
   fileprivate let storage: Storage
 
-  fileprivate enum Modifier: Equatable, Hashable {
+  fileprivate enum Modifier: Equatable, Hashable, Sendable {
     case accessibilityHeading(AccessibilityHeadingLevel)
     case accessibilityLabel(TextState)
     case accessibilityTextContentType(AccessibilityTextContentType)
@@ -70,7 +70,7 @@ public struct TextState: Equatable, Hashable {
     case underline(isActive: Bool, pattern: LineStylePattern?, color: Color?)
   }
 
-  public enum FontWidth: String, Equatable, Hashable {
+  public enum FontWidth: String, Equatable, Hashable, Sendable {
     case compressed
     case condensed
     case expanded
@@ -89,7 +89,7 @@ public struct TextState: Equatable, Hashable {
     #endif
   }
 
-  public enum LineStylePattern: String, Equatable, Hashable {
+  public enum LineStylePattern: String, Equatable, Hashable, Sendable {
     case dash
     case dashDot
     case dashDotDot
@@ -108,7 +108,9 @@ public struct TextState: Equatable, Hashable {
     }
   }
 
-  fileprivate enum Storage: Equatable, Hashable {
+  // NB: LocalizedStringKey is documented as being Sendable, but its conformance appears to be
+  //     unavailable.
+  fileprivate enum Storage: Equatable, Hashable, @unchecked Sendable {
     indirect case concatenated(TextState, TextState)
     case localized(LocalizedStringKey, tableName: String?, bundle: Bundle?, comment: StaticString?)
     case verbatim(String)
@@ -305,7 +307,7 @@ extension TextState {
 // MARK: Accessibility
 
 extension TextState {
-  public enum AccessibilityTextContentType: String, Equatable, Hashable {
+  public enum AccessibilityTextContentType: String, Equatable, Hashable, Sendable {
     case console, fileSystem, messaging, narrative, plain, sourceCode, spreadsheet, wordProcessing
 
     #if compiler(>=5.5.1)
@@ -325,7 +327,7 @@ extension TextState {
     #endif
   }
 
-  public enum AccessibilityHeadingLevel: String, Equatable, Hashable {
+  public enum AccessibilityHeadingLevel: String, Equatable, Hashable, Sendable {
     case h1, h2, h3, h4, h5, h6, unspecified
 
     #if compiler(>=5.5.1)
@@ -739,14 +741,3 @@ extension TextState: CustomDumpRepresentable {
     return dumpHelp(self)
   }
 }
-
-// MARK: - Sendable Annotations
-
-#if swift(>=5.9)
-extension TextState: Sendable {}
-extension TextState.AccessibilityHeadingLevel: Sendable {}
-extension TextState.AccessibilityTextContentType: Sendable {}
-extension TextState.FontWidth: Sendable {}
-extension TextState.LineStylePattern: Sendable {}
-extension TextState.Modifier: Sendable {}
-#endif


### PR DESCRIPTION
SwiftUI only annotated some of the types that are used in this package with Xcode 15 / Swift 5.9, so we need to guard conformances only when compiling with Swift 5.9 or higher.

Thanks @rowjo for starting this work in https://github.com/pointfreeco/swiftui-navigation/pull/116.