### PR TITLE
Require BindWorkaround for iOS17 in NavigationDestination

### DIFF
--- a/Sources/SwiftUINavigation/NavigationDestination.swift
+++ b/Sources/SwiftUINavigation/NavigationDestination.swift
@@ -100,6 +100,9 @@
   }
 
   private let requiresBindWorkaround = {
+    if #available(iOS 17, *) {
+      return true
+    }
     guard #available(iOS 16.4, macOS 13.3, tvOS 16.4, watchOS 9.4, *)
     else { return true }
     return false

--- a/Sources/SwiftUINavigation/NavigationDestination.swift
+++ b/Sources/SwiftUINavigation/NavigationDestination.swift
@@ -100,7 +100,7 @@
   }
 
   private let requiresBindWorkaround = {
-    if #available(iOS 17, *) {
+    if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
       return true
     }
     guard #available(iOS 16.4, macOS 13.3, tvOS 16.4, watchOS 9.4, *)


### PR DESCRIPTION
Fix for a regression in iOS17, where deep linking would not be possible any more.
For more details, please look at: https://github.com/pointfreeco/swiftui-navigation/discussions/121