### PR TITLE
Allow For Compilation on Windows & Add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,27 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Run tests
         run: make test
+
+  windows:
+    name: Windows
+    strategy:
+      matrix:
+        os: [windows-latest]
+        config: ['debug', 'release']
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: compnerd/gha-setup-swift@main
+        with:
+          branch: swift-5.8.1-release
+          tag: 5.8.1-RELEASE
+      - uses: actions/checkout@v3
+      - name: Build
+        run: swift build -c ${{ matrix.config }}
+      - name: Run tests (debug only)
+        # There is an issue that exists in the 5.8.1 toolchain
+        # which fails on release configuration testing, but
+        # this issue is fixed 5.9 so we can remove the if once
+        # that is generally available.
+        if: ${{ matrix.config == 'debug' }}
+        run: swift test

--- a/Sources/SwiftUINavigation/Alert.swift
+++ b/Sources/SwiftUINavigation/Alert.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import SwiftUI
 
 extension View {
@@ -303,3 +304,4 @@ extension View {
 
   // TODO: support iOS <15?
 }
+#endif // canImport(SwiftUI)

--- a/Sources/SwiftUINavigation/Binding.swift
+++ b/Sources/SwiftUINavigation/Binding.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import SwiftUI
 
 extension Binding {
@@ -187,3 +188,4 @@ extension Binding {
     )
   }
 }
+#endif // canImport(SwiftUI)

--- a/Sources/SwiftUINavigation/ConfirmationDialog.swift
+++ b/Sources/SwiftUINavigation/ConfirmationDialog.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import SwiftUI
 
 extension View {
@@ -313,3 +314,4 @@ extension View {
 
   // TODO: support iOS <15?
 }
+#endif // canImport(SwiftUI)

--- a/Sources/SwiftUINavigation/FullScreenCover.swift
+++ b/Sources/SwiftUINavigation/FullScreenCover.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import SwiftUI
 
 extension View {
@@ -87,3 +88,4 @@ extension View {
     self.fullScreenCover(unwrapping: `enum`.case(casePath), onDismiss: onDismiss, content: content)
   }
 }
+#endif // canImport(SwiftUI)

--- a/Sources/SwiftUINavigation/IfCaseLet.swift
+++ b/Sources/SwiftUINavigation/IfCaseLet.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import SwiftUI
 
 /// A view that computes content by extracting a case from a binding to an enum and passing a
@@ -90,3 +91,4 @@ extension IfCaseLet where ElseContent == EmptyView {
     self.ifContent = ifContent
   }
 }
+#endif // canImport(SwiftUI)

--- a/Sources/SwiftUINavigation/IfLet.swift
+++ b/Sources/SwiftUINavigation/IfLet.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import SwiftUI
 
 /// A view that computes content by unwrapping a binding to an optional and passing a non-optional
@@ -84,3 +85,4 @@ extension IfLet where ElseContent == EmptyView {
     self.init(value, then: ifContent, else: { EmptyView() })
   }
 }
+#endif // canImport(SwiftUI)

--- a/Sources/SwiftUINavigation/Internal/Binding+Internal.swift
+++ b/Sources/SwiftUINavigation/Internal/Binding+Internal.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import SwiftUI
 
 extension Binding {
@@ -11,3 +12,4 @@ extension Binding {
     )
   }
 }
+#endif // canImport(SwiftUI)

--- a/Sources/SwiftUINavigation/Internal/Deprecations.swift
+++ b/Sources/SwiftUINavigation/Internal/Deprecations.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import SwiftUI
 
 // NB: Deprecated after 0.5.0
@@ -218,3 +219,4 @@ extension NavigationLink {
     )
   }
 }
+#endif // canImport(SwiftUI)

--- a/Sources/SwiftUINavigation/Internal/Exports.swift
+++ b/Sources/SwiftUINavigation/Internal/Exports.swift
@@ -1,2 +1,4 @@
+#if canImport(SwiftUI)
 @_exported import CasePaths
 @_exported import SwiftUINavigationCore
+#endif // canImport(SwiftUI)

--- a/Sources/SwiftUINavigation/NavigationDestination.swift
+++ b/Sources/SwiftUINavigation/NavigationDestination.swift
@@ -1,4 +1,4 @@
-#if swift(>=5.7)
+#if swift(>=5.7) && canImport(SwiftUI)
   import SwiftUI
 
   @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
@@ -107,4 +107,4 @@
     else { return true }
     return false
   }()
-#endif
+#endif // swift(>=5.7) && canImport(SwiftUI)

--- a/Sources/SwiftUINavigation/NavigationLink.swift
+++ b/Sources/SwiftUINavigation/NavigationLink.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import SwiftUI
 
 extension NavigationLink {
@@ -133,3 +134,4 @@ extension NavigationLink {
     )
   }
 }
+#endif // canImport(SwiftUI)

--- a/Sources/SwiftUINavigation/Popover.swift
+++ b/Sources/SwiftUINavigation/Popover.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import SwiftUI
 
 extension View {
@@ -96,3 +97,4 @@ extension View {
     )
   }
 }
+#endif // canImport(SwiftUI)

--- a/Sources/SwiftUINavigation/Sheet.swift
+++ b/Sources/SwiftUINavigation/Sheet.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import SwiftUI
 
 #if canImport(UIKit)
@@ -87,3 +88,4 @@ extension View {
     self.sheet(unwrapping: `enum`.case(casePath), onDismiss: onDismiss, content: content)
   }
 }
+#endif // canImport(SwiftUI)

--- a/Sources/SwiftUINavigation/Switch.swift
+++ b/Sources/SwiftUINavigation/Switch.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import SwiftUI
 @_spi(RuntimeWarn) import SwiftUINavigationCore
 
@@ -1114,3 +1115,4 @@ private func describeCase<Enum>(_ enum: Enum) -> String {
   }
   return "\(type).\(`case`)"
 }
+#endif // canImport(SwiftUI)

--- a/Sources/SwiftUINavigation/WithState.swift
+++ b/Sources/SwiftUINavigation/WithState.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import SwiftUI
 
 /// A container view that provides a binding to another view.
@@ -44,3 +45,4 @@ public struct WithState<Value, Content: View>: View {
     self.content(self.$value)
   }
 }
+#endif // canImport(SwiftUI)

--- a/Sources/SwiftUINavigationCore/AlertState.swift
+++ b/Sources/SwiftUINavigationCore/AlertState.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import CustomDump
 import SwiftUI
 
@@ -258,3 +259,4 @@ extension Alert {
     }
   }
 }
+#endif // canImport(SwiftUI)

--- a/Sources/SwiftUINavigationCore/Bind.swift
+++ b/Sources/SwiftUINavigationCore/Bind.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import SwiftUI
 
 extension View {
@@ -82,3 +83,4 @@ extension FocusState.Binding: _Bindable {}
 extension SceneStorage: _Bindable {}
 
 extension State: _Bindable {}
+#endif // canImport(SwiftUI)

--- a/Sources/SwiftUINavigationCore/ButtonState.swift
+++ b/Sources/SwiftUINavigationCore/ButtonState.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import CustomDump
 import SwiftUI
 
@@ -368,3 +369,4 @@ func typeName(_ type: Any.Type) -> String {
     )
   return sanitizedName
 }
+#endif // canImport(SwiftUI)

--- a/Sources/SwiftUINavigationCore/ButtonStateBuilder.swift
+++ b/Sources/SwiftUINavigationCore/ButtonStateBuilder.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 @resultBuilder
 public enum ButtonStateBuilder<Action> {
   public static func buildArray(_ components: [[ButtonState<Action>]]) -> [ButtonState<Action>] {
@@ -30,3 +31,4 @@ public enum ButtonStateBuilder<Action> {
     component ?? []
   }
 }
+#endif // canImport(SwiftUI)

--- a/Sources/SwiftUINavigationCore/ConfirmationDialogState.swift
+++ b/Sources/SwiftUINavigationCore/ConfirmationDialogState.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import CustomDump
 import SwiftUI
 
@@ -288,3 +289,4 @@ extension Visibility {
     }
   }
 }
+#endif // canImport(SwiftUI)

--- a/Sources/SwiftUINavigationCore/Internal/Deprecations.swift
+++ b/Sources/SwiftUINavigationCore/Internal/Deprecations.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import SwiftUI
 
 // NB: Deprecated after 0.5.0
@@ -307,3 +308,5 @@ extension ActionSheet {
     )
   }
 }
+
+#endif // canImport(SwiftUI)

--- a/Sources/SwiftUINavigationCore/Internal/RuntimeWarnings.swift
+++ b/Sources/SwiftUINavigationCore/Internal/RuntimeWarnings.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 @_spi(RuntimeWarn)
 @_transparent
 @inline(__always)
@@ -70,3 +71,4 @@ public func runtimeWarn(
     }()
   #endif
 #endif
+#endif // canImport(SwiftUI)

--- a/Sources/SwiftUINavigationCore/TextState.swift
+++ b/Sources/SwiftUINavigationCore/TextState.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import CustomDump
 import SwiftUI
 
@@ -741,3 +742,4 @@ extension TextState: CustomDumpRepresentable {
     return dumpHelp(self)
   }
 }
+#endif // canImport(SwiftUI)

--- a/Tests/SwiftUINavigationTests/AlertTests.swift
+++ b/Tests/SwiftUINavigationTests/AlertTests.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import CustomDump
 import SwiftUI
 import SwiftUINavigation
@@ -117,3 +118,4 @@ private struct TestView: View {
     }
   }
 }
+#endif // canImport(SwiftUI)

--- a/Tests/SwiftUINavigationTests/ButtonStateTests.swift
+++ b/Tests/SwiftUINavigationTests/ButtonStateTests.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import CustomDump
 import SwiftUI
 import SwiftUINavigation
@@ -30,3 +31,4 @@ final class ButtonStateTests: XCTestCase {
     }
   }
 }
+#endif // canImport(SwiftUI)

--- a/Tests/SwiftUINavigationTests/SwiftUINavigationTests.swift
+++ b/Tests/SwiftUINavigationTests/SwiftUINavigationTests.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import SwiftUI
 import XCTest
 
@@ -60,3 +61,4 @@ final class SwiftUINavigationTests: XCTestCase {
     XCTAssertEqual(failure.wrappedValue, nil)
   }
 }
+#endif // canImport(SwiftUI)

--- a/Tests/SwiftUINavigationTests/TextStateTests.swift
+++ b/Tests/SwiftUINavigationTests/TextStateTests.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import CustomDump
 import SwiftUINavigation
 import XCTest
@@ -72,3 +73,4 @@ final class TextStateTests: XCTestCase {
     )
   }
 }
+#endif // canImport(SwiftUI)


### PR DESCRIPTION
This PR ensures that this library can build on platforms that do not include SwiftUI. Effectively this PR will make this library a no-op for any platform on which SwiftUI does *not* exist. This allows for it to be safely included in any upstream Package (such as TCA) and will not prevent compilation. 

Additionally, this adds a Windows CI job to ensure that the no-op status of this library is preserved or that testing is successful going forward.