### PR TITLE
Updating documentation to demonstrate accurate use of AlertState<Action> handling

### DIFF
--- a/Sources/SwiftUINavigationCore/AlertState.swift
+++ b/Sources/SwiftUINavigationCore/AlertState.swift
@@ -36,11 +36,13 @@ import SwiftUI
 /// ```swift
 /// class HomeScreenModel: ObservableObject {
 ///   // ...
-///   func alertButtonTapped(_ action: AlertAction) {
+///   func alertButtonTapped(_ action: AlertAction?) {
 ///     switch action {
 ///     case .delete:
 ///       // ...
 ///     case .removeFromHomeScreen:
+///       // ...
+///     case .none:
 ///       // ...
 ///     }
 ///   }


### PR DESCRIPTION

Problem:
Due to lack of handling `none` path of AlertAction, following warning was rendered.

`'alert(unwrapping:action:)' is deprecated: 'View.alert' now passes an optional action to its handler to allow you to handle action-less dismissals.` 

