### PR TITLE
Add `Sendable` conformance to `AlertState`

### DIFF
--- a/Sources/SwiftUINavigationCore/AlertState.swift
+++ b/Sources/SwiftUINavigationCore/AlertState.swift
@@ -212,6 +212,8 @@
     }
   }
 
+  extension AlertState: Sendable where Action: Sendable {}
+
   // MARK: - SwiftUI bridging
 
   extension Alert {


### PR DESCRIPTION
Follow up after #120. This useful wherever `AlertState` is used in `Sendable` contexts.