### PR TITLE
Add `HashableObject` protocol

### DIFF
--- a/Sources/SwiftUINavigation/Documentation.docc/Articles/Navigation.md
+++ b/Sources/SwiftUINavigation/Documentation.docc/Articles/Navigation.md
@@ -116,3 +116,7 @@ Button {
 
 - ``SwiftUI/View/navigationDestination(unwrapping:destination:)``
 - ``SwiftUI/NavigationLink/init(unwrapping:onNavigate:destination:label:)``
+
+### Supporting types
+
+- ``HashableObject``

--- a/Sources/SwiftUINavigation/HashableObject.swift
+++ b/Sources/SwiftUINavigation/HashableObject.swift
@@ -1,0 +1,20 @@
+/// A protocol that adds a default implementation of `Hashable` to an object based off its object
+/// identity.
+///
+/// SwiftUI's navigation tools requires `Identifiable` and `Hashable` conformances throughout its
+/// APIs, for example `sheet(item:)` requires `Identifiable`, while `navigationDestination(item:)`
+/// and `NavigationLink.init(value:)` require `Hashable`. While `Identifiable` conformances come for
+/// free on objects based on object identity, there is no such mechanism for `Hashable`. This
+/// protocol addresses this shortcoming by providing default implementations of `==` and
+/// `hash(into:)`.
+public protocol HashableObject: AnyObject, Hashable {}
+
+extension HashableObject {
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs === rhs
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(ObjectIdentifier(self))
+  }
+}


### PR DESCRIPTION
SwiftUI's built-in navigation tools requires hashability and identifiability of objects, and while objects get identity for free, we must manually equate and hash objects by their object identity. Instead, the library can vend a protocol with default conformances.

This would immediately clean up some code in our SyncUps app.