### PR TITLE
Add `navigationDestination(item:)` backport, `NavigationLink.init(item:)`

### DIFF
--- a/Sources/SwiftUINavigation/NavigationLink.swift
+++ b/Sources/SwiftUINavigation/NavigationLink.swift
@@ -1,6 +1,24 @@
 #if canImport(SwiftUI)
   import SwiftUI
 
+  @available(
+    iOS, introduced: 13, deprecated: 16,
+    message:
+      "use NavigationLink(value:label:), or navigationDestination(isPresented:destination:), inside a NavigationStack or NavigationSplitView"
+  )
+  @available(
+    macOS, introduced: 10.15, deprecated: 13,
+    message:
+      "use NavigationLink(value:label:), or navigationDestination(isPresented:destination:), inside a NavigationStack or NavigationSplitView")
+  @available(
+    tvOS, introduced: 13, deprecated: 16,
+    message:
+      "use NavigationLink(value:label:), or navigationDestination(isPresented:destination:), inside a NavigationStack or NavigationSplitView")
+  @available(
+    watchOS, introduced: 6, deprecated: 9,
+    message:
+      "use NavigationLink(value:label:), or navigationDestination(isPresented:destination:), inside a NavigationStack or NavigationSplitView"
+  )
   extension NavigationLink {
     /// Creates a navigation link that presents the destination view when a bound value is
     /// non-`nil`.
@@ -50,10 +68,6 @@
     ///     will automatically write `nil` to `value`.
     ///   - destination: A view for the navigation link to present.
     ///   - label: A view builder to produce a label describing the `destination` to present.
-    @available(iOS, introduced: 13, deprecated: 16)
-    @available(macOS, introduced: 10.15, deprecated: 13)
-    @available(tvOS, introduced: 13, deprecated: 16)
-    @available(watchOS, introduced: 6, deprecated: 9)
     public init<Value, WrappedDestination>(
       unwrapping value: Binding<Value?>,
       onNavigate: @escaping (_ isActive: Bool) -> Void,

--- a/Sources/SwiftUINavigationCore/NavigationDestination+Vanilla.swift
+++ b/Sources/SwiftUINavigationCore/NavigationDestination+Vanilla.swift
@@ -1,0 +1,79 @@
+#if canImport(SwiftUI)
+  import SwiftUI
+
+  @available(iOS, introduced: 16, obsoleted: 17)
+  @available(macOS, introduced: 13, obsoleted: 14)
+  @available(tvOS, introduced: 16, obsoleted: 17)
+  @available(watchOS, introduced: 9, obsoleted: 10)
+  extension View {
+    /// A backport of SwiftUI's `navigationDestination(item:)`.
+    ///
+    /// > Important: This modifier is a wrapper around `navigationDestination(isPresented:)`, which
+    /// > is known to be buggy (especially pre-iOS 16.4, etc.). It is not guaranteed, nor is it
+    /// > expected, to behave exactly like SwiftUI's built-in `navigationDestination(item:)`
+    /// > modifier. Be sure to test both this backport and the native modifier in your application
+    /// > to ensure acceptable behavior.
+    public func navigationDestination<Item: Hashable, Destination: View>(
+      item: Binding<Item?>,
+      @ViewBuilder destination: (Item) -> Destination
+    ) -> some View {
+      self._navigationDestination(isPresented: item.isPresent()) {
+        item.wrappedValue.map(destination)
+      }
+    }
+
+    @ViewBuilder
+    public func _navigationDestination<Destination: View>(
+      isPresented: Binding<Bool>,
+      @ViewBuilder destination: () -> Destination
+    ) -> some View {
+      if requiresBindWorkaround {
+        self.modifier(
+          _NavigationDestinationBindWorkaround(isPresented: isPresented, destination: destination())
+        )
+      } else {
+        self.navigationDestination(isPresented: isPresented, destination: destination)
+      }
+    }
+  }
+
+  // NB: This view modifier works around a bug in SwiftUI's built-in modifier:
+  // https://gist.github.com/mbrandonw/f8b94957031160336cac6898a919cbb7#file-fb11056434-md
+  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+  private struct _NavigationDestinationBindWorkaround<Destination: View>: ViewModifier {
+    @Binding var isPresented: Bool
+    let destination: Destination
+
+    @State private var isPresentedState = false
+
+    public func body(content: Content) -> some View {
+      content
+        .navigationDestination(isPresented: self.$isPresentedState) { self.destination }
+        .bind(self.$isPresented, to: self.$isPresentedState)
+    }
+  }
+
+  private let requiresBindWorkaround = {
+    if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
+      return true
+    }
+    guard #available(iOS 16.4, macOS 13.3, tvOS 16.4, watchOS 9.4, *)
+    else { return true }
+    return false
+  }()
+
+  extension Binding {
+    // NB: This should remain in sync with the public interface in the `SwiftUINavigation` module.
+    fileprivate func isPresent<Wrapped>() -> Binding<Bool>
+    where Value == Wrapped? {
+      .init(
+        get: { self.wrappedValue != nil },
+        set: { isPresent, transaction in
+          if !isPresent {
+            self.transaction(transaction).wrappedValue = nil
+          }
+        }
+      )
+    }
+  }
+#endif  // canImport(SwiftUI)

--- a/Sources/SwiftUINavigationCore/NavigationLink+Vanilla.swift
+++ b/Sources/SwiftUINavigationCore/NavigationLink+Vanilla.swift
@@ -1,0 +1,55 @@
+#if canImport(SwiftUI)
+  import SwiftUI
+
+  @available(
+    iOS, introduced: 13, deprecated: 16,
+    message:
+      "use NavigationLink(value:label:), or navigationDestination(isPresented:destination:), inside a NavigationStack or NavigationSplitView"
+  )
+  @available(
+    macOS, introduced: 10.15, deprecated: 13,
+    message:
+      "use NavigationLink(value:label:), or navigationDestination(isPresented:destination:), inside a NavigationStack or NavigationSplitView")
+  @available(
+    tvOS, introduced: 13, deprecated: 16,
+    message:
+      "use NavigationLink(value:label:), or navigationDestination(isPresented:destination:), inside a NavigationStack or NavigationSplitView")
+  @available(
+    watchOS, introduced: 6, deprecated: 9,
+    message:
+      "use NavigationLink(value:label:), or navigationDestination(isPresented:destination:), inside a NavigationStack or NavigationSplitView"
+  )
+  extension NavigationLink {
+    /// Creates a navigation link that presents the view corresponding to a value.
+    ///
+    /// > Tip: This initializer is provided for applications deploying to older OSes that want to
+    /// > drive navigation with an optional.
+    ///
+    /// - Parameters:
+    ///   - value: A value to present.
+    ///   - item: A binding to the presented value.
+    ///   - destination: A view for the navigation link to present.
+    ///   - label: A view builder to produce a label describing the destination to present.
+    public init<T, D: View>(
+      value: @autoclosure @escaping () -> T,
+      item: Binding<T?>,
+      @ViewBuilder destination: (T) -> D,
+      @ViewBuilder label: () -> Label
+    ) where Destination == D? {
+      self.init(
+        destination: item.wrappedValue.map(destination),
+        isActive: Binding(
+          get: { item.wrappedValue != nil },
+          set: { newValue, transaction in
+            if newValue {
+              item.transaction(transaction).wrappedValue = value()
+            } else {
+              item.transaction(transaction).wrappedValue = nil
+            }
+          }
+        ),
+        label: label
+      )
+    }
+  }
+#endif  // canImport(SwiftUI)


### PR DESCRIPTION
Now that TCA is using more vanilla modifiers, we could maybe back-port some, and introduce others that are more compatible with optional-driven navigation.