### PR TITLE
Add iOS 16-compatible `navigationDestination(item:)` to core

### DIFF
--- a/Sources/SwiftUINavigation/Documentation.docc/Articles/Bindings.md
+++ b/Sources/SwiftUINavigation/Documentation.docc/Articles/Bindings.md
@@ -78,7 +78,6 @@ struct SignInView: View {
 
 ### Binding transformations
 
-- ``SwiftUI/Binding/isPresent()``
 - ``SwiftUI/Binding/removeDuplicates()``
 - ``SwiftUI/Binding/removeDuplicates(by:)``
 

--- a/Sources/SwiftUINavigationCore/Documentation.docc/SwiftUINavigationCore.md
+++ b/Sources/SwiftUINavigationCore/Documentation.docc/SwiftUINavigationCore.md
@@ -1,6 +1,6 @@
 # ``SwiftUINavigationCore``
 
-A few core types included in SwiftUI Navigation.
+A few core types and modifiers included in SwiftUI Navigation.
 
 ## Topics
 
@@ -10,3 +10,19 @@ A few core types included in SwiftUI Navigation.
 - ``AlertState``
 - ``ConfirmationDialogState``
 - ``ButtonState``
+
+### Alert and dialog modifiers
+
+- ``SwiftUI/View/alert(item:title:actions:message:)``
+- ``SwiftUI/View/alert(item:title:actions:)``
+- ``SwiftUI/View/confirmationDialog(item:titleVisibility:title:actions:message:)``
+- ``SwiftUI/View/confirmationDialog(item:titleVisibility:title:actions:)``
+
+### Bindings
+
+- ``SwiftUI/Binding/isPresent()``
+- ``SwiftUI/View/bind(_:to:)``
+
+### Navigation
+
+- ``SwiftUI/View/navigationDestination(item:destination:)``

--- a/Sources/SwiftUINavigationCore/NavigationDestination.swift
+++ b/Sources/SwiftUINavigationCore/NavigationDestination.swift
@@ -1,23 +1,25 @@
-import SwiftUI
+#if canImport(SwiftUI)
+  import SwiftUI
 
-@available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
-extension View {
-  /// Associates a destination view with a bound value for use within a navigation stack or
-  /// navigation split view.
-  ///
-  /// See `SwiftUI.View.navigationDestination(item:destination:)` for more information.
-  ///
-  /// - Parameters:
-  ///   - item: A binding to the data presented, or `nil` if nothing is currently presented.
-  ///   - destination: A view builder that defines a view to display when `item` is not `nil`.
-  public func navigationDestination<D, C: View>(
-    item: Binding<D?>,
-    @ViewBuilder destination: @escaping (D) -> C
-  ) -> some View {
-    navigationDestination(isPresented: item.isPresent()) {
-      if let item = item.wrappedValue {
-        destination(item)
+  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+  extension View {
+    /// Associates a destination view with a bound value for use within a navigation stack or
+    /// navigation split view.
+    ///
+    /// See `SwiftUI.View.navigationDestination(item:destination:)` for more information.
+    ///
+    /// - Parameters:
+    ///   - item: A binding to the data presented, or `nil` if nothing is currently presented.
+    ///   - destination: A view builder that defines a view to display when `item` is not `nil`.
+    public func navigationDestination<D, C: View>(
+      item: Binding<D?>,
+      @ViewBuilder destination: @escaping (D) -> C
+    ) -> some View {
+      navigationDestination(isPresented: item.isPresent()) {
+        if let item = item.wrappedValue {
+          destination(item)
+        }
       }
     }
   }
-}
+#endif  // canImport(SwiftUI)

--- a/Sources/SwiftUINavigationCore/NavigationDestination.swift
+++ b/Sources/SwiftUINavigationCore/NavigationDestination.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+@available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+extension View {
+  /// Associates a destination view with a bound value for use within a navigation stack or
+  /// navigation split view.
+  ///
+  /// See `SwiftUI.View.navigationDestination(item:destination:)` for more information.
+  ///
+  /// - Parameters:
+  ///   - item: A binding to the data presented, or `nil` if nothing is currently presented.
+  ///   - destination: A view builder that defines a view to display when `item` is not `nil`.
+  public func navigationDestination<D, C: View>(
+    item: Binding<D?>,
+    @ViewBuilder destination: @escaping (D) -> C
+  ) -> some View {
+    navigationDestination(isPresented: item.isPresent()) {
+      if let item = item.wrappedValue {
+        destination(item)
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds an iOS 16-compatible version of `navigationDestination(item:)` to core. Unlike SwiftUI's version, it is not constrained to `Hashable`, so it has its own overload resolution and should not conflict with the built-in modifier in iOS 17+.