### PR TITLE
Prevent case navigation binding from writing to other cases

### DIFF
--- a/Sources/SwiftUINavigation/Binding.swift
+++ b/Sources/SwiftUINavigation/Binding.swift
@@ -141,19 +141,6 @@
     }
   }
 
-//  extension CasePathable {
-//    fileprivate subscript<Member>(
-//      keyPath: KeyPath<Self.AllCasePaths, AnyCasePath<Self, Member>>
-//    ) -> Member? {
-//      get { Self.allCasePaths[keyPath: keyPath].extract(from: self) }
-//      set {
-//        let casePath = Self.allCasePaths[keyPath: keyPath]
-//        guard let newValue, casePath.extract(from: self) != nil else { return }
-//        self = casePath.embed(newValue)
-//      }
-//    }
-//  }
-
   extension Optional where Wrapped: CasePathable {
     fileprivate subscript<Member>(
       keyPath: KeyPath<Wrapped.AllCasePaths, AnyCasePath<Wrapped, Member>>

--- a/Sources/SwiftUINavigation/Binding.swift
+++ b/Sources/SwiftUINavigation/Binding.swift
@@ -131,7 +131,9 @@
     fileprivate subscript<Member>(
       keyPath: KeyPath<Self.AllCasePaths, AnyCasePath<Self, Member>>
     ) -> Member? {
-      get { Self.allCasePaths[keyPath: keyPath].extract(from: self) }
+      get {
+        Self.allCasePaths[keyPath: keyPath].extract(from: self)
+      }
       set {
         guard let newValue else { return }
         self = Self.allCasePaths[keyPath: keyPath].embed(newValue)
@@ -139,20 +141,31 @@
     }
   }
 
+//  extension CasePathable {
+//    fileprivate subscript<Member>(
+//      keyPath: KeyPath<Self.AllCasePaths, AnyCasePath<Self, Member>>
+//    ) -> Member? {
+//      get { Self.allCasePaths[keyPath: keyPath].extract(from: self) }
+//      set {
+//        let casePath = Self.allCasePaths[keyPath: keyPath]
+//        guard let newValue, casePath.extract(from: self) != nil else { return }
+//        self = casePath.embed(newValue)
+//      }
+//    }
+//  }
+
   extension Optional where Wrapped: CasePathable {
     fileprivate subscript<Member>(
       keyPath: KeyPath<Wrapped.AllCasePaths, AnyCasePath<Wrapped, Member>>
     ) -> Member? {
       get {
-        guard let wrapped = self else { return nil }
-        return Wrapped.allCasePaths[keyPath: keyPath].extract(from: wrapped)
+        self.flatMap(Wrapped.allCasePaths[keyPath: keyPath].extract(from:))
       }
       set {
-        guard let newValue else {
-          self = nil
-          return
-        }
-        self = Wrapped.allCasePaths[keyPath: keyPath].embed(newValue)
+        let casePath = Wrapped.allCasePaths[keyPath: keyPath]
+        guard self.flatMap(casePath.extract(from:)) != nil
+        else { return }
+        self = newValue.map(casePath.embed)
       }
     }
   }

--- a/Tests/SwiftUINavigationTests/BindingTests.swift
+++ b/Tests/SwiftUINavigationTests/BindingTests.swift
@@ -34,17 +34,6 @@
       XCTAssertEqual(status, .outOfStock(isOnBackOrder: true))
     }
 
-    func testCaseCannotReplaceOtherCase_2() throws {
-      let status = Binding(initialValue: Status.inStock(quantity: 1))
-
-      let inStock = try XCTUnwrap(status.inStock)
-
-      status.wrappedValue = .outOfStock(isOnBackOrder: true)
-
-      inStock.wrappedValue = 42
-      XCTAssertEqual(status.wrappedValue, .outOfStock(isOnBackOrder: true))
-    }
-
     func testDestinationCannotReplaceOtherDestination() throws {
       @Binding var destination: Status?
       _destination = Binding(initialValue: .inStock(quantity: 1))

--- a/Tests/SwiftUINavigationTests/BindingTests.swift
+++ b/Tests/SwiftUINavigationTests/BindingTests.swift
@@ -1,4 +1,4 @@
-#if canImport(SwiftUI)
+#if swift(>=5.9) && canImport(SwiftUI)
   import CustomDump
   import SwiftUI
   import SwiftUINavigation

--- a/Tests/SwiftUINavigationTests/BindingTests.swift
+++ b/Tests/SwiftUINavigationTests/BindingTests.swift
@@ -1,0 +1,70 @@
+#if canImport(SwiftUI)
+  import CustomDump
+  import SwiftUI
+  import SwiftUINavigation
+  import XCTest
+
+  final class BindingTests: XCTestCase {
+    @CasePathable
+    @dynamicMemberLookup
+    enum Status: Equatable {
+      case inStock(quantity: Int)
+      case outOfStock(isOnBackOrder: Bool)
+    }
+
+    func testCaseLookup() throws {
+      @Binding var status: Status
+      _status = Binding(initialValue: .inStock(quantity: 1))
+
+      let inStock = try XCTUnwrap($status.inStock)
+      inStock.wrappedValue += 1
+
+      XCTAssertEqual(status, .inStock(quantity: 2))
+    }
+
+    func testCaseCannotReplaceOtherCase() throws {
+      @Binding var status: Status
+      _status = Binding(initialValue: .inStock(quantity: 1))
+
+      let inStock = try XCTUnwrap($status.inStock)
+
+      status = .outOfStock(isOnBackOrder: true)
+
+      inStock.wrappedValue = 42
+      XCTAssertEqual(status, .outOfStock(isOnBackOrder: true))
+    }
+
+    func testCaseCannotReplaceOtherCase_2() throws {
+      let status = Binding(initialValue: Status.inStock(quantity: 1))
+
+      let inStock = try XCTUnwrap(status.inStock)
+
+      status.wrappedValue = .outOfStock(isOnBackOrder: true)
+
+      inStock.wrappedValue = 42
+      XCTAssertEqual(status.wrappedValue, .outOfStock(isOnBackOrder: true))
+    }
+
+    func testDestinationCannotReplaceOtherDestination() throws {
+      @Binding var destination: Status?
+      _destination = Binding(initialValue: .inStock(quantity: 1))
+
+      let inStock = try XCTUnwrap($destination.inStock)
+
+      destination = .outOfStock(isOnBackOrder: true)
+
+      inStock.wrappedValue = 42
+      XCTAssertEqual(destination, .outOfStock(isOnBackOrder: true))
+    }
+  }
+
+  private extension Binding {
+    init(initialValue: Value) {
+      var value = initialValue
+      self.init(
+        get: { value },
+        set: { value = $0 }
+      )
+    }
+  }
+#endif  // canImport(SwiftUI)


### PR DESCRIPTION
Currently, a stale binding to a `destinationA` can dismiss or replace a `destinationB`, which shouldn't be allowed.