### PR TITLE
Add `sheet(item:id:)`

### DIFF
--- a/Sources/SwiftUINavigation/FullScreenCover.swift
+++ b/Sources/SwiftUINavigation/FullScreenCover.swift
@@ -1,7 +1,31 @@
 #if canImport(SwiftUI)
   import SwiftUI
 
+  @available(iOS 14, tvOS 14, watchOS 7, *)
+  @available(macOS, unavailable)
   extension View {
+    /// Presents a full-screen cover using a binding as a data source for the sheet's content based
+    /// on the identity of the underlying item.
+    ///
+    /// - Parameters:
+    ///   - item: A binding to an optional source of truth for the sheet. When `item` is non-`nil`,
+    ///     the system passes the item's content to the modifier's closure. You display this content
+    ///     in a sheet that you create that the system displays to the user. If `item` changes, the
+    ///     system dismisses the sheet and replaces it with a new one using the same process.
+    ///   - id: The key path to the provided item's identifier.
+    ///   - onDismiss: The closure to execute when dismissing the sheet.
+    ///   - content: A closure returning the content of the sheet.
+    public func fullScreenCover<Item, ID: Hashable, Content: View>(
+      item: Binding<Item?>,
+      id: KeyPath<Item, ID>,
+      onDismiss: (() -> Void)? = nil,
+      @ViewBuilder content: @escaping (Item) -> Content
+    ) -> some View {
+      self.fullScreenCover(item: item[id: id], onDismiss: onDismiss) { _ in
+        item.wrappedValue.map(content)
+      }
+    }
+
     /// Presents a full-screen cover using a binding as a data source for the sheet's content.
     ///
     /// SwiftUI comes with a `fullScreenCover(item:)` view modifier that is powered by a binding to
@@ -36,15 +60,13 @@
     ///
     /// - Parameters:
     ///   - value: A binding to a source of truth for the sheet. When `value` is non-`nil`, a
-    ///     non-optional binding to the value is passed to the `content` closure. You use this binding
-    ///     to produce content that the system presents to the user in a sheet. Changes made to the
-    ///     sheet's binding will be reflected back in the source of truth. Likewise, changes to
-    ///     `value` are instantly reflected in the sheet. If `value` becomes `nil`, the sheet is
+    ///     non-optional binding to the value is passed to the `content` closure. You use this
+    ///     binding to produce content that the system presents to the user in a sheet. Changes made
+    ///     to the sheet's binding will be reflected back in the source of truth. Likewise, changes
+    ///     to `value` are instantly reflected in the sheet. If `value` becomes `nil`, the sheet is
     ///     dismissed.
     ///   - onDismiss: The closure to execute when dismissing the sheet.
     ///   - content: A closure returning the content of the sheet.
-    @available(iOS 14, tvOS 14, watchOS 7, *)
-    @available(macOS, unavailable)
     public func fullScreenCover<Value, Content>(
       unwrapping value: Binding<Value?>,
       onDismiss: (() -> Void)? = nil,

--- a/Sources/SwiftUINavigation/Internal/Identified.swift
+++ b/Sources/SwiftUINavigation/Internal/Identified.swift
@@ -1,0 +1,10 @@
+struct Identified<ID: Hashable>: Identifiable {
+  let id: ID
+}
+
+extension Optional {
+  subscript<ID: Hashable>(id keyPath: KeyPath<Wrapped, ID>) -> Identified<ID>? {
+    get { (self?[keyPath: keyPath]).map(Identified.init) }
+    set { if newValue == nil { self = nil } }
+  }
+}

--- a/Sources/SwiftUINavigation/Popover.swift
+++ b/Sources/SwiftUINavigation/Popover.swift
@@ -1,6 +1,8 @@
 #if canImport(SwiftUI)
   import SwiftUI
 
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
   extension View {
     /// Presents a popover using a binding as a data source for the sheet's content based on the
     /// identity of the underlying item.
@@ -77,8 +79,6 @@
     ///   - arrowEdge: The edge of the `attachmentAnchor` that defines the location of the popover's
     ///     arrow.
     ///   - content: A closure returning the content of the popover.
-    @available(tvOS, unavailable)
-    @available(watchOS, unavailable)
     public func popover<Value, Content: View>(
       unwrapping value: Binding<Value?>,
       attachmentAnchor: PopoverAttachmentAnchor = .rect(.bounds),

--- a/Sources/SwiftUINavigation/Popover.swift
+++ b/Sources/SwiftUINavigation/Popover.swift
@@ -2,6 +2,37 @@
   import SwiftUI
 
   extension View {
+    /// Presents a popover using a binding as a data source for the sheet's content based on the
+    /// identity of the underlying item.
+    ///
+    /// - Parameters:
+    ///   - item: A binding to an optional source of truth for the popover. When `item` is
+    ///     non-`nil`, the system passes the item's content to the modifier's closure. You display
+    ///     this content in a popover that you create that the system displays to the user. If `item`
+    ///     changes, the system dismisses the popover and replaces it with a new one using the same
+    ///     process.
+    ///   - id: The key path to the provided item's identifier.
+    ///   - attachmentAnchor: The positioning anchor that defines the attachment point of the
+    ///     popover.
+    ///   - arrowEdge: The edge of the `attachmentAnchor` that defines the location of the popover's
+    ///     arrow.
+    ///   - content: A closure returning the content of the popover.
+    public func popover<Item, ID: Hashable, Content: View>(
+      item: Binding<Item?>,
+      id: KeyPath<Item, ID>,
+      attachmentAnchor: PopoverAttachmentAnchor = .rect(.bounds),
+      arrowEdge: Edge = .top,
+      @ViewBuilder content: @escaping (Item) -> Content
+    ) -> some View {
+      self.popover(
+        item: item[id: id],
+        attachmentAnchor: attachmentAnchor,
+        arrowEdge: arrowEdge
+      ) { _ in
+        item.wrappedValue.map(content)
+      }
+    }
+
     /// Presents a popover using a binding as a data source for the popover's content.
     ///
     /// SwiftUI comes with a `popover(item:)` view modifier that is powered by a binding to some
@@ -48,12 +79,12 @@
     ///   - content: A closure returning the content of the popover.
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
-    public func popover<Value, Content>(
+    public func popover<Value, Content: View>(
       unwrapping value: Binding<Value?>,
       attachmentAnchor: PopoverAttachmentAnchor = .rect(.bounds),
       arrowEdge: Edge = .top,
       @ViewBuilder content: @escaping (Binding<Value>) -> Content
-    ) -> some View where Content: View {
+    ) -> some View {
       self.popover(
         isPresented: value.isPresent(),
         attachmentAnchor: attachmentAnchor,

--- a/Sources/SwiftUINavigation/Sheet.swift
+++ b/Sources/SwiftUINavigation/Sheet.swift
@@ -8,6 +8,28 @@
   #endif
 
   extension View {
+    /// Presents a sheet using a binding as a data source for the sheet's content based on the
+    /// identity of the underlying item.
+    ///
+    /// - Parameters:
+    ///   - item: A binding to an optional source of truth for the sheet. When `item` is non-`nil`,
+    ///     the system passes the item's content to the modifier's closure. You display this content
+    ///     in a sheet that you create that the system displays to the user. If `item` changes, the
+    ///     system dismisses the sheet and replaces it with a new one using the same process.
+    ///   - id: The key path to the provided item's identifier.
+    ///   - onDismiss: The closure to execute when dismissing the sheet.
+    ///   - content: A closure returning the content of the sheet.
+    public func sheet<Item, ID: Hashable, Content: View>(
+      item: Binding<Item?>,
+      id: KeyPath<Item, ID>,
+      onDismiss: (() -> Void)? = nil,
+      @ViewBuilder content: @escaping (Item) -> Content
+    ) -> some View {
+      self.sheet(item: item[id: id], onDismiss: onDismiss) { _ in
+        item.wrappedValue.map(content)
+      }
+    }
+
     /// Presents a sheet using a binding as a data source for the sheet's content.
     ///
     /// SwiftUI comes with a `sheet(item:)` view modifier that is powered by a binding to some


### PR DESCRIPTION
`ForEach` has a convenient initializer that takes a key path to some hashable identifier so that the element isn't forced into an identifiable conformance, but `sheet`, `fullScreenCover` and `popover` aren't given the same affordances. Let's close the gap.