### PR TITLE
Remove `sheet(unwrapping:)`, etc., helpers for `sheet(item:)` overloads

### DIFF
--- a/Examples/CaseStudies/01-Alerts.swift
+++ b/Examples/CaseStudies/01-Alerts.swift
@@ -7,28 +7,28 @@ struct OptionalAlerts: View {
 
   var body: some View {
     List {
-      Stepper("Number: \(self.model.count)", value: self.$model.count)
+      Stepper("Number: \(model.count)", value: $model.count)
       Button {
-        Task { await self.model.numberFactButtonTapped() }
+        Task { await model.numberFactButtonTapped() }
       } label: {
         HStack {
           Text("Get number fact")
-          if self.model.isLoading {
+          if model.isLoading {
             Spacer()
             ProgressView()
           }
         }
       }
-      .disabled(self.model.isLoading)
+      .disabled(model.isLoading)
     }
-    .alert(item: self.$model.fact) {
+    .alert(item: $model.fact) {
       Text("Fact about \($0.number)")
     } actions: {
       Button("Get another fact about \($0.number)") {
-        Task { await self.model.numberFactButtonTapped() }
+        Task { await model.numberFactButtonTapped() }
       }
       Button("Close", role: .cancel) {
-        self.model.fact = nil
+        model.fact = nil
       }
     } message: {
       Text($0.description)
@@ -45,9 +45,9 @@ private class FeatureModel {
 
   @MainActor
   func numberFactButtonTapped() async {
-    self.isLoading = true
-    self.fact = await getNumberFact(self.count)
-    self.isLoading = false
+    isLoading = true
+    defer { isLoading = false }
+    fact = await getNumberFact(count)
   }
 }
 

--- a/Examples/CaseStudies/02-ConfirmationDialogs.swift
+++ b/Examples/CaseStudies/02-ConfirmationDialogs.swift
@@ -7,24 +7,24 @@ struct OptionalConfirmationDialogs: View {
 
   var body: some View {
     List {
-      Stepper("Number: \(self.model.count)", value: self.$model.count)
+      Stepper("Number: \(model.count)", value: $model.count)
       Button {
-        Task { await self.model.numberFactButtonTapped() }
+        Task { await model.numberFactButtonTapped() }
       } label: {
         HStack {
           Text("Get number fact")
-          if self.model.isLoading {
+          if model.isLoading {
             Spacer()
             ProgressView()
           }
         }
       }
-      .disabled(self.model.isLoading)
-      .confirmationDialog(item: self.$model.fact, titleVisibility: .visible) {
+      .disabled(model.isLoading)
+      .confirmationDialog(item: $model.fact, titleVisibility: .visible) {
         Text("Fact about \($0.number)")
       } actions: {
         Button("Get another fact about \($0.number)") {
-          Task { await self.model.numberFactButtonTapped() }
+          Task { await model.numberFactButtonTapped() }
         }
       } message: {
         Text($0.description)
@@ -42,9 +42,9 @@ private class FeatureModel {
 
   @MainActor
   func numberFactButtonTapped() async {
-    self.isLoading = true
-    self.fact = await getNumberFact(self.count)
-    self.isLoading = false
+    isLoading = true
+    defer { isLoading = false }
+    fact = await getNumberFact(count)
   }
 }
 

--- a/Examples/CaseStudies/03-Sheets.swift
+++ b/Examples/CaseStudies/03-Sheets.swift
@@ -7,14 +7,14 @@ struct OptionalSheets: View {
   var body: some View {
     List {
       Section {
-        Stepper("Number: \(self.model.count)", value: self.$model.count)
+        Stepper("Number: \(model.count)", value: $model.count)
 
         HStack {
           Button("Get number fact") {
-            Task { await self.model.numberFactButtonTapped() }
+            Task { await model.numberFactButtonTapped() }
           }
 
-          if self.model.isLoading {
+          if model.isLoading {
             Spacer()
             ProgressView()
           }
@@ -24,28 +24,28 @@ struct OptionalSheets: View {
       }
 
       Section {
-        ForEach(self.model.savedFacts) { fact in
+        ForEach(model.savedFacts) { fact in
           Text(fact.description)
         }
-        .onDelete { self.model.removeSavedFacts(atOffsets: $0) }
+        .onDelete { model.removeSavedFacts(atOffsets: $0) }
       } header: {
         Text("Saved Facts")
       }
     }
-    .sheet(unwrapping: self.$model.fact) { $fact in
+    .sheet(item: $model.fact) { $fact in
       NavigationStack {
         FactEditor(fact: $fact.description)
-          .disabled(self.model.isLoading)
-          .foregroundColor(self.model.isLoading ? .gray : nil)
+          .disabled(model.isLoading)
+          .foregroundColor(model.isLoading ? .gray : nil)
           .toolbar {
             ToolbarItem(placement: .cancellationAction) {
               Button("Cancel") {
-                self.model.cancelButtonTapped()
+                model.cancelButtonTapped()
               }
             }
             ToolbarItem(placement: .confirmationAction) {
               Button("Save") {
-                self.model.saveButtonTapped(fact: fact)
+                model.saveButtonTapped(fact: fact)
               }
             }
           }
@@ -60,7 +60,7 @@ private struct FactEditor: View {
 
   var body: some View {
     VStack {
-      TextEditor(text: self.$fact)
+      TextEditor(text: $fact)
     }
     .padding()
     .navigationTitle("Fact editor")
@@ -76,41 +76,41 @@ private class FeatureModel {
   private var task: Task<Void, Never>?
 
   deinit {
-    self.task?.cancel()
+    task?.cancel()
   }
 
   @MainActor
   func numberFactButtonTapped() async {
-    self.isLoading = true
-    self.fact = Fact(description: "\(self.count) is still loading...", number: self.count)
-    self.task = Task {
+    isLoading = true
+    fact = Fact(description: "\(count) is still loading...", number: count)
+    task = Task {
       let fact = await getNumberFact(self.count)
-      self.isLoading = false
+      isLoading = false
       guard !Task.isCancelled
       else { return }
       self.fact = fact
     }
-    await self.task?.value
+    await task?.value
   }
 
   @MainActor
   func cancelButtonTapped() {
-    self.task?.cancel()
-    self.task = nil
-    self.fact = nil
+    task?.cancel()
+    task = nil
+    fact = nil
   }
 
   @MainActor
   func saveButtonTapped(fact: Fact) {
-    self.task?.cancel()
-    self.task = nil
-    self.savedFacts.append(fact)
+    task?.cancel()
+    task = nil
+    savedFacts.append(fact)
     self.fact = nil
   }
 
   @MainActor
   func removeSavedFacts(atOffsets offsets: IndexSet) {
-    self.savedFacts.remove(atOffsets: offsets)
+    savedFacts.remove(atOffsets: offsets)
   }
 }
 

--- a/Examples/CaseStudies/04-Popovers.swift
+++ b/Examples/CaseStudies/04-Popovers.swift
@@ -7,29 +7,29 @@ struct OptionalPopovers: View {
   var body: some View {
     List {
       Section {
-        Stepper("Number: \(self.model.count)", value: self.$model.count)
+        Stepper("Number: \(model.count)", value: $model.count)
 
         HStack {
           Button("Get number fact") {
-            Task { await self.model.numberFactButtonTapped() }
+            Task { await model.numberFactButtonTapped() }
           }
-          .popover(unwrapping: self.$model.fact, arrowEdge: .bottom) { $fact in
+          .popover(item: $model.fact, arrowEdge: .bottom) { $fact in
             NavigationStack {
               FactEditor(fact: $fact.description)
-                .disabled(self.model.isLoading)
-                .foregroundColor(self.model.isLoading ? .gray : nil)
+                .disabled(model.isLoading)
+                .foregroundColor(model.isLoading ? .gray : nil)
                 .navigationBarItems(
                   leading: Button("Cancel") {
-                    self.model.cancelButtonTapped()
+                    model.cancelButtonTapped()
                   },
                   trailing: Button("Save") {
-                    self.model.saveButtonTapped(fact: fact)
+                    model.saveButtonTapped(fact: fact)
                   }
                 )
             }
           }
 
-          if self.model.isLoading {
+          if model.isLoading {
             Spacer()
             ProgressView()
           }
@@ -39,10 +39,10 @@ struct OptionalPopovers: View {
       }
 
       Section {
-        ForEach(self.model.savedFacts) { fact in
+        ForEach(model.savedFacts) { fact in
           Text(fact.description)
         }
-        .onDelete { self.model.removeSavedFacts(atOffsets: $0) }
+        .onDelete { model.removeSavedFacts(atOffsets: $0) }
       } header: {
         Text("Saved Facts")
       }
@@ -56,7 +56,7 @@ private struct FactEditor: View {
 
   var body: some View {
     VStack {
-      TextEditor(text: self.$fact)
+      TextEditor(text: $fact)
     }
     .padding()
     .navigationTitle("Fact editor")
@@ -77,36 +77,36 @@ private class FeatureModel {
 
   @MainActor
   func numberFactButtonTapped() async {
-    self.isLoading = true
-    self.fact = Fact(description: "\(self.count) is still loading...", number: self.count)
-    self.task = Task {
+    isLoading = true
+    fact = Fact(description: "\(count) is still loading...", number: count)
+    task = Task {
       let fact = await getNumberFact(self.count)
-      self.isLoading = false
+      isLoading = false
       guard !Task.isCancelled
       else { return }
       self.fact = fact
     }
-    await self.task?.value
+    await task?.value
   }
 
   @MainActor
   func cancelButtonTapped() {
-    self.task?.cancel()
-    self.task = nil
-    self.fact = nil
+    task?.cancel()
+    task = nil
+    fact = nil
   }
 
   @MainActor
   func saveButtonTapped(fact: Fact) {
-    self.task?.cancel()
-    self.task = nil
-    self.savedFacts.append(fact)
+    task?.cancel()
+    task = nil
+    savedFacts.append(fact)
     self.fact = nil
   }
 
   @MainActor
   func removeSavedFacts(atOffsets offsets: IndexSet) {
-    self.savedFacts.remove(atOffsets: offsets)
+    savedFacts.remove(atOffsets: offsets)
   }
 }
 

--- a/Examples/CaseStudies/05-FullScreenCovers.swift
+++ b/Examples/CaseStudies/05-FullScreenCovers.swift
@@ -7,14 +7,14 @@ struct OptionalFullScreenCovers: View {
   var body: some View {
     List {
       Section {
-        Stepper("Number: \(self.model.count)", value: self.$model.count)
+        Stepper("Number: \(model.count)", value: $model.count)
 
         HStack {
           Button("Get number fact") {
-            Task { await self.model.numberFactButtonTapped() }
+            Task { await model.numberFactButtonTapped() }
           }
 
-          if self.model.isLoading {
+          if model.isLoading {
             Spacer()
             ProgressView()
           }
@@ -24,28 +24,28 @@ struct OptionalFullScreenCovers: View {
       }
 
       Section {
-        ForEach(self.model.savedFacts) { fact in
+        ForEach(model.savedFacts) { fact in
           Text(fact.description)
         }
-        .onDelete { self.model.removeSavedFacts(atOffsets: $0) }
+        .onDelete { model.removeSavedFacts(atOffsets: $0) }
       } header: {
         Text("Saved Facts")
       }
     }
-    .fullScreenCover(unwrapping: self.$model.fact) { $fact in
+    .fullScreenCover(item: $model.fact) { $fact in
       NavigationStack {
         FactEditor(fact: $fact.description)
-          .disabled(self.model.isLoading)
-          .foregroundColor(self.model.isLoading ? .gray : nil)
+          .disabled(model.isLoading)
+          .foregroundColor(model.isLoading ? .gray : nil)
           .toolbar {
             ToolbarItem(placement: .cancellationAction) {
               Button("Cancel") {
-                self.model.cancelButtonTapped()
+                model.cancelButtonTapped()
               }
             }
             ToolbarItem(placement: .confirmationAction) {
               Button("Save") {
-                self.model.saveButtonTapped(fact: fact)
+                model.saveButtonTapped(fact: fact)
               }
             }
           }
@@ -60,7 +60,7 @@ private struct FactEditor: View {
 
   var body: some View {
     VStack {
-      TextEditor(text: self.$fact)
+      TextEditor(text: $fact)
     }
     .padding()
     .navigationTitle("Fact editor")
@@ -77,36 +77,36 @@ private class FeatureModel {
 
   @MainActor
   func numberFactButtonTapped() async {
-    self.isLoading = true
-    self.fact = Fact(description: "\(self.count) is still loading...", number: self.count)
-    self.task = Task {
-      let fact = await getNumberFact(self.count)
-      self.isLoading = false
+    isLoading = true
+    fact = Fact(description: "\(count) is still loading...", number: count)
+    task = Task {
+      let fact = await getNumberFact(count)
+      isLoading = false
       guard !Task.isCancelled
       else { return }
       self.fact = fact
     }
-    await self.task?.value
+    await task?.value
   }
 
   @MainActor
   func cancelButtonTapped() {
-    self.task?.cancel()
-    self.task = nil
-    self.fact = nil
+    task?.cancel()
+    task = nil
+    fact = nil
   }
 
   @MainActor
   func saveButtonTapped(fact: Fact) {
-    self.task?.cancel()
-    self.task = nil
-    self.savedFacts.append(fact)
+    task?.cancel()
+    task = nil
+    savedFacts.append(fact)
     self.fact = nil
   }
 
   @MainActor
   func removeSavedFacts(atOffsets offsets: IndexSet) {
-    self.savedFacts.remove(atOffsets: offsets)
+    savedFacts.remove(atOffsets: offsets)
   }
 }
 

--- a/Examples/CaseStudies/06-NavigationDestinations.swift
+++ b/Examples/CaseStudies/06-NavigationDestinations.swift
@@ -34,7 +34,7 @@ struct NavigationDestinations: View {
       }
     }
     .navigationTitle("Destinations")
-    .navigationDestination(unwrapping: $model.fact) { $fact in
+    .navigationDestination(item: $model.fact) { $fact in
       FactEditor(fact: $fact.description)
         .disabled(model.isLoading)
         .foregroundColor(model.isLoading ? .gray : nil)

--- a/Examples/CaseStudies/06-NavigationDestinations.swift
+++ b/Examples/CaseStudies/06-NavigationDestinations.swift
@@ -8,14 +8,14 @@ struct NavigationDestinations: View {
   var body: some View {
     List {
       Section {
-        Stepper("Number: \(self.model.count)", value: self.$model.count)
+        Stepper("Number: \(model.count)", value: $model.count)
 
         HStack {
           Button("Get number fact") {
-            Task { await self.model.numberFactButtonTapped() }
+            Task { await model.numberFactButtonTapped() }
           }
 
-          if self.model.isLoading {
+          if model.isLoading {
             Spacer()
             ProgressView()
           }
@@ -25,29 +25,29 @@ struct NavigationDestinations: View {
       }
 
       Section {
-        ForEach(self.model.savedFacts) { fact in
+        ForEach(model.savedFacts) { fact in
           Text(fact.description)
         }
-        .onDelete { self.model.removeSavedFacts(atOffsets: $0) }
+        .onDelete { model.removeSavedFacts(atOffsets: $0) }
       } header: {
         Text("Saved Facts")
       }
     }
     .navigationTitle("Destinations")
-    .navigationDestination(unwrapping: self.$model.fact) { $fact in
+    .navigationDestination(unwrapping: $model.fact) { $fact in
       FactEditor(fact: $fact.description)
-        .disabled(self.model.isLoading)
-        .foregroundColor(self.model.isLoading ? .gray : nil)
+        .disabled(model.isLoading)
+        .foregroundColor(model.isLoading ? .gray : nil)
         .navigationBarBackButtonHidden(true)
         .toolbar {
           ToolbarItem(placement: .cancellationAction) {
             Button("Cancel") {
-              Task { await self.model.cancelButtonTapped() }
+              Task { await model.cancelButtonTapped() }
             }
           }
           ToolbarItem(placement: .confirmationAction) {
             Button("Save") {
-              Task { await self.model.saveButtonTapped(fact: fact) }
+              Task { await model.saveButtonTapped(fact: fact) }
             }
           }
         }
@@ -61,9 +61,9 @@ private struct FactEditor: View {
   var body: some View {
     VStack {
       if #available(iOS 14, *) {
-        TextEditor(text: self.$fact)
+        TextEditor(text: $fact)
       } else {
-        TextField("Untitled", text: self.$fact)
+        TextField("Untitled", text: $fact)
       }
     }
     .padding()
@@ -80,48 +80,48 @@ private class FeatureModel {
   private var task: Task<Void, Never>?
 
   deinit {
-    self.task?.cancel()
+    task?.cancel()
   }
 
   @MainActor
   func setFactNavigation(isActive: Bool) async {
     if isActive {
-      self.isLoading = true
-      self.fact = Fact(description: "\(self.count) is still loading...", number: self.count)
-      self.task = Task {
+      isLoading = true
+      fact = Fact(description: "\(count) is still loading...", number: count)
+      task = Task {
         let fact = await getNumberFact(self.count)
-        self.isLoading = false
+        isLoading = false
         guard !Task.isCancelled
         else { return }
         self.fact = fact
       }
-      await self.task?.value
+      await task?.value
     } else {
-      self.task?.cancel()
-      self.task = nil
-      self.fact = nil
+      task?.cancel()
+      task = nil
+      fact = nil
     }
   }
 
   @MainActor
   func numberFactButtonTapped() async {
-    await self.setFactNavigation(isActive: true)
+    await setFactNavigation(isActive: true)
   }
 
   @MainActor
   func cancelButtonTapped() async {
-    await self.setFactNavigation(isActive: false)
+    await setFactNavigation(isActive: false)
   }
 
   @MainActor
   func saveButtonTapped(fact: Fact) async {
-    self.savedFacts.append(fact)
-    await self.setFactNavigation(isActive: false)
+    savedFacts.append(fact)
+    await setFactNavigation(isActive: false)
   }
 
   @MainActor
   func removeSavedFacts(atOffsets offsets: IndexSet) {
-    self.savedFacts.remove(atOffsets: offsets)
+    savedFacts.remove(atOffsets: offsets)
   }
 }
 

--- a/Examples/CaseStudies/07-NavigationLinks.swift
+++ b/Examples/CaseStudies/07-NavigationLinks.swift
@@ -32,7 +32,7 @@ struct OptionalNavigationLinks: View {
         Text("Saved Facts")
       }
     }
-    .navigationDestination(unwrapping: $model.fact) { $fact in
+    .navigationDestination(item: $model.fact) { $fact in
       FactEditor(fact: $fact.description)
         .disabled(model.isLoading)
         .foregroundColor(model.isLoading ? .gray : nil)

--- a/Examples/CaseStudies/07-NavigationLinks.swift
+++ b/Examples/CaseStudies/07-NavigationLinks.swift
@@ -7,11 +7,11 @@ struct OptionalNavigationLinks: View {
   var body: some View {
     List {
       Section {
-        Stepper("Number: \(self.model.count)", value: self.$model.count)
+        Stepper("Number: \(model.count)", value: $model.count)
 
         HStack {
           Button("Get number fact") {
-            Task { await self.model.setFactNavigation(isActive: true) }
+            Task { await model.setFactNavigation(isActive: true) }
           }
 
           if self.model.isLoading {
@@ -24,28 +24,28 @@ struct OptionalNavigationLinks: View {
       }
 
       Section {
-        ForEach(self.model.savedFacts) { fact in
+        ForEach(model.savedFacts) { fact in
           Text(fact.description)
         }
-        .onDelete { self.model.removeSavedFacts(atOffsets: $0) }
+        .onDelete { model.removeSavedFacts(atOffsets: $0) }
       } header: {
         Text("Saved Facts")
       }
     }
-    .navigationDestination(unwrapping: self.$model.fact) { $fact in
+    .navigationDestination(unwrapping: $model.fact) { $fact in
       FactEditor(fact: $fact.description)
-        .disabled(self.model.isLoading)
-        .foregroundColor(self.model.isLoading ? .gray : nil)
+        .disabled(model.isLoading)
+        .foregroundColor(model.isLoading ? .gray : nil)
         .navigationBarBackButtonHidden(true)
         .toolbar {
           ToolbarItem(placement: .cancellationAction) {
             Button("Cancel") {
-              Task { await self.model.cancelButtonTapped() }
+              Task { await model.cancelButtonTapped() }
             }
           }
           ToolbarItem(placement: .confirmationAction) {
             Button("Save") {
-              Task { await self.model.saveButtonTapped(fact: fact) }
+              Task { await model.saveButtonTapped(fact: fact) }
             }
           }
         }
@@ -59,7 +59,7 @@ private struct FactEditor: View {
 
   var body: some View {
     VStack {
-      TextEditor(text: self.$fact)
+      TextEditor(text: $fact)
     }
     .padding()
     .navigationTitle("Fact editor")
@@ -75,43 +75,43 @@ private class FeatureModel {
   private var task: Task<Void, Never>?
 
   deinit {
-    self.task?.cancel()
+    task?.cancel()
   }
 
   @MainActor
   func setFactNavigation(isActive: Bool) async {
     if isActive {
-      self.isLoading = true
-      self.fact = Fact(description: "\(self.count) is still loading...", number: self.count)
-      self.task = Task {
+      isLoading = true
+      fact = Fact(description: "\(count) is still loading...", number: count)
+      task = Task {
         let fact = await getNumberFact(self.count)
-        self.isLoading = false
+        isLoading = false
         guard !Task.isCancelled
         else { return }
         self.fact = fact
       }
-      await self.task?.value
+      await task?.value
     } else {
-      self.task?.cancel()
-      self.task = nil
-      self.fact = nil
+      task?.cancel()
+      task = nil
+      fact = nil
     }
   }
 
   @MainActor
   func cancelButtonTapped() async {
-    await self.setFactNavigation(isActive: false)
+    await setFactNavigation(isActive: false)
   }
 
   @MainActor
   func saveButtonTapped(fact: Fact) async {
-    self.savedFacts.append(fact)
-    await self.setFactNavigation(isActive: false)
+    savedFacts.append(fact)
+    await setFactNavigation(isActive: false)
   }
 
   @MainActor
   func removeSavedFacts(atOffsets offsets: IndexSet) {
-    self.savedFacts.remove(atOffsets: offsets)
+    savedFacts.remove(atOffsets: offsets)
   }
 }
 

--- a/Examples/CaseStudies/08-Routing.swift
+++ b/Examples/CaseStudies/08-Routing.swift
@@ -39,11 +39,11 @@ struct Routing: View {
       }
 
       Section {
-        Text("Count: \(self.count)")
+        Text("Count: \(count)")
       }
 
       Button("Alert") {
-        self.destination = .alert(
+        destination = .alert(
           AlertState {
             TextState("Update count?")
           } actions: {
@@ -58,7 +58,7 @@ struct Routing: View {
       }
 
       Button("Confirmation dialog") {
-        self.destination = .confirmationDialog(
+        destination = .confirmationDialog(
           ConfirmationDialogState(titleVisibility: .visible) {
             TextState("Update count?")
           } actions: {
@@ -73,41 +73,41 @@ struct Routing: View {
       }
 
       Button("Link") {
-        self.destination = .link(self.count)
+        destination = .link(count)
       }
 
       Button("Sheet") {
-        self.destination = .sheet(self.count)
+        destination = .sheet(count)
       }
     }
     .navigationTitle("Routing")
-    .alert(self.$destination.alert) { action in
+    .alert($destination.alert) { action in
       switch action {
       case .randomize?:
-        self.count = .random(in: 0...1_000)
+        count = .random(in: 0...1_000)
       case .reset?:
-        self.count = 0
+        count = 0
       case nil:
         break
       }
     }
-    .confirmationDialog(self.$destination.confirmationDialog) { action in
+    .confirmationDialog($destination.confirmationDialog) { action in
       switch action {
       case .decrement?:
-        self.count -= 1
+        count -= 1
       case .increment?:
-        self.count += 1
+        count += 1
       case nil:
         break
       }
     }
-    .navigationDestination(unwrapping: self.$destination.link) { $count in
+    .navigationDestination(item: $destination.link) { $count in
       Form {
         Stepper("Count: \(count)", value: $count)
       }
       .navigationTitle("Routing link")
     }
-    .sheet(unwrapping: self.$destination.sheet) { $count in
+    .sheet(item: $destination.sheet, id: \.self) { $count in
       NavigationStack {
         Form {
           Stepper("Count: \(count)", value: $count)

--- a/Examples/CaseStudies/09-CustomComponents.swift
+++ b/Examples/CaseStudies/09-CustomComponents.swift
@@ -25,16 +25,16 @@ struct CustomComponents: View {
 
       Button("Show bottom menu") {
         withAnimation {
-          self.count = 0
+          count = 0
         }
       }
 
-      if let count = self.count, count > 0 {
+      if let count = count, count > 0 {
         Text("Current count: \(count)")
           .transition(.opacity)
       }
     }
-    .bottomMenu(unwrapping: self.$count) { $count in
+    .bottomMenu(item: $count) { $count in
       Stepper("Number: \(count)", value: $count.animation())
     }
     .navigationTitle("Custom components")
@@ -49,13 +49,13 @@ where BottomMenuContent: View {
   func body(content: Content) -> some View {
     content.overlay(
       ZStack(alignment: .bottom) {
-        if self.isActive {
+        if isActive {
           Rectangle()
             .fill(Color.black.opacity(0.4))
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .onTapGesture {
               withAnimation {
-                self.isActive = false
+                isActive = false
               }
             }
             .zIndex(1)
@@ -83,7 +83,7 @@ extension View {
     @ViewBuilder content: @escaping () -> Content
   ) -> some View
   where Content: View {
-    self.modifier(
+    modifier(
       BottomMenuModifier(
         isActive: isActive,
         content: content
@@ -91,28 +91,16 @@ extension View {
     )
   }
 
-  fileprivate func bottomMenu<Value, Content>(
-    unwrapping value: Binding<Value?>,
-    @ViewBuilder content: @escaping (Binding<Value>) -> Content
+  fileprivate func bottomMenu<Item, Content>(
+    item: Binding<Item?>,
+    @ViewBuilder content: @escaping (Binding<Item>) -> Content
   ) -> some View
   where Content: View {
-    self.modifier(
+    modifier(
       BottomMenuModifier(
-        isActive: value.isPresent(),
-        content: { Binding(unwrapping: value).map(content) }
+        isActive: item.isPresent(),
+        content: { Binding(unwrapping: item).map(content) }
       )
-    )
-  }
-
-  fileprivate func bottomMenu<Enum, Case, Content>(
-    unwrapping value: Binding<Enum?>,
-    case casePath: AnyCasePath<Enum, Case>,
-    @ViewBuilder content: @escaping (Binding<Case>) -> Content
-  ) -> some View
-  where Content: View {
-    self.bottomMenu(
-      unwrapping: value.case(casePath),
-      content: content
     )
   }
 }

--- a/Examples/CaseStudies/10-SynchronizedBindings.swift
+++ b/Examples/CaseStudies/10-SynchronizedBindings.swift
@@ -19,20 +19,20 @@ struct SynchronizedBindings: View {
       }
 
       Section {
-        TextField("Username", text: self.$model.username)
-          .focused(self.$focusedField, equals: .username)
+        TextField("Username", text: $model.username)
+          .focused($focusedField, equals: .username)
 
-        SecureField("Password", text: self.$model.password)
-          .focused(self.$focusedField, equals: .password)
+        SecureField("Password", text: $model.password)
+          .focused($focusedField, equals: .password)
 
         Button("Sign In") {
-          self.model.signInButtonTapped()
+          model.signInButtonTapped()
         }
         .buttonStyle(.borderedProminent)
       }
       .textFieldStyle(.roundedBorder)
     }
-    .bind(self.$model.focusedField, to: self.$focusedField)
+    .bind($model.focusedField, to: $focusedField)
     .navigationTitle("Synchronized focus")
   }
 }
@@ -49,12 +49,12 @@ private class FeatureModel {
   var username: String = ""
 
   func signInButtonTapped() {
-    if self.username.isEmpty {
-      self.focusedField = .username
-    } else if self.password.isEmpty {
-      self.focusedField = .password
+    if username.isEmpty {
+      focusedField = .username
+    } else if password.isEmpty {
+      focusedField = .password
     } else {
-      self.focusedField = nil
+      focusedField = nil
     }
   }
 }

--- a/Examples/CaseStudies/11-IfLet.swift
+++ b/Examples/CaseStudies/11-IfLet.swift
@@ -17,25 +17,25 @@ struct IfLetCaseStudy: View {
       Section {
         Text(readMe)
       }
-      Binding(unwrapping: self.$editableString).map { $string in
+      Binding(unwrapping: $editableString).map { $string in
         VStack {
           TextField("Edit string", text: $string)
           HStack {
             Button("Discard") {
-              self.editableString = nil
+              editableString = nil
             }
             Spacer()
             Button("Save") {
-              self.string = string
-              self.editableString = nil
+              string = string
+              editableString = nil
             }
           }
         }
       }
-      if self.editableString == nil {
-        Text("\(self.string)")
+      if editableString == nil {
+        Text("\(string)")
         Button("Edit") {
-          self.editableString = self.string
+          editableString = string
         }
       }
     }

--- a/Examples/CaseStudies/12-IfCaseLet.swift
+++ b/Examples/CaseStudies/12-IfCaseLet.swift
@@ -24,25 +24,25 @@ struct IfCaseLetCaseStudy: View {
       Section {
         Text(readMe)
       }
-      self.$editableString.active.map { $string in
+      $editableString.active.map { $string in
         VStack {
           TextField("Edit string", text: $string)
           HStack {
             Button("Discard", role: .cancel) {
-              self.editableString = .inactive
+              editableString = .inactive
             }
             Spacer()
             Button("Save") {
-              self.string = string
-              self.editableString = .inactive
+              string = string
+              editableString = .inactive
             }
           }
         }
       }
-      if !self.editableString.is(\.active) {
-        Text("\(self.string)")
+      if !editableString.is(\.active) {
+        Text("\(string)")
         Button("Edit") {
-          self.editableString = .active(self.string)
+          editableString = .active(string)
         }
       }
     }

--- a/Examples/CaseStudies/FactClient.swift
+++ b/Examples/CaseStudies/FactClient.swift
@@ -5,7 +5,7 @@ struct Fact: Identifiable {
   let number: Int
 
   var id: AnyHashable {
-    [self.description as AnyHashable, self.number]
+    [description as AnyHashable, number]
   }
 }
 

--- a/Examples/Inventory/Inventory.swift
+++ b/Examples/Inventory/Inventory.swift
@@ -5,7 +5,7 @@ import SwiftUINavigation
 @Observable
 class InventoryModel {
   var inventory: IdentifiedArrayOf<ItemRowModel> {
-    didSet { self.bind() }
+    didSet { bind() }
   }
   var destination: Destination?
 
@@ -25,46 +25,46 @@ class InventoryModel {
   }
 
   func delete(item: Item) {
-    _ = self.inventory.remove(id: item.id)
+    _ = inventory.remove(id: item.id)
   }
 
   func add(item: Item) {
     withAnimation {
-      self.inventory.append(ItemRowModel(item: item))
-      self.destination = nil
+      inventory.append(ItemRowModel(item: item))
+      destination = nil
     }
   }
 
   func addButtonTapped() {
-    self.destination = .add(Item(color: nil, name: "", status: .inStock(quantity: 1)))
+    destination = .add(Item(color: nil, name: "", status: .inStock(quantity: 1)))
   }
 
   func cancelButtonTapped() {
-    self.destination = nil
+    destination = nil
   }
 
   func cancelEditButtonTapped() {
-    self.destination = nil
+    destination = nil
   }
 
   func commitEdit(item: Item) {
-    self.inventory[id: item.id]?.item = item
-    self.destination = nil
+    inventory[id: item.id]?.item = item
+    destination = nil
   }
 
   private func bind() {
-    for itemRowModel in self.inventory {
+    for itemRowModel in inventory {
       itemRowModel.onDelete = { [weak self, weak itemRowModel] in
         guard let self, let itemRowModel else { return }
-        self.delete(item: itemRowModel.item)
+        delete(item: itemRowModel.item)
       }
       itemRowModel.onDuplicate = { [weak self] item in
         guard let self else { return }
-        self.add(item: item)
+        add(item: item)
       }
       itemRowModel.onTap = { [weak self, weak itemRowModel] in
         guard let self, let itemRowModel else { return }
-        self.destination = .edit(itemRowModel.item)
+        destination = .edit(itemRowModel.item)
       }
     }
   }
@@ -75,43 +75,43 @@ struct InventoryView: View {
 
   var body: some View {
     List {
-      ForEach(self.model.inventory) {
+      ForEach(model.inventory) {
         ItemRowView(model: $0)
       }
     }
     .toolbar {
       ToolbarItem(placement: .primaryAction) {
-        Button("Add") { self.model.addButtonTapped() }
+        Button("Add") { model.addButtonTapped() }
       }
     }
     .navigationTitle("Inventory")
-    .navigationDestination(unwrapping: self.$model.destination.edit) { $item in
+    .navigationDestination(item: $model.destination.edit) { $item in
       ItemView(item: $item)
         .navigationBarTitle("Edit")
         .navigationBarBackButtonHidden(true)
         .toolbar {
           ToolbarItem(placement: .cancellationAction) {
             Button("Cancel") {
-              self.model.cancelEditButtonTapped()
+              model.cancelEditButtonTapped()
             }
           }
           ToolbarItem(placement: .primaryAction) {
             Button("Save") {
-              self.model.commitEdit(item: item)
+              model.commitEdit(item: item)
             }
           }
         }
     }
-    .sheet(unwrapping: self.$model.destination.add) { $itemToAdd in
+    .sheet(item: $model.destination.add) { $itemToAdd in
       NavigationStack {
         ItemView(item: $itemToAdd)
           .navigationTitle("Add")
           .toolbar {
             ToolbarItem(placement: .cancellationAction) {
-              Button("Cancel") { self.model.cancelButtonTapped() }
+              Button("Cancel") { model.cancelButtonTapped() }
             }
             ToolbarItem(placement: .primaryAction) {
-              Button("Save") { self.model.add(item: itemToAdd) }
+              Button("Save") { model.add(item: itemToAdd) }
             }
           }
       }

--- a/Examples/Inventory/ItemRow.swift
+++ b/Examples/Inventory/ItemRow.swift
@@ -21,16 +21,16 @@ class ItemRowModel: Identifiable {
   var onDuplicate: (Item) -> Void = unimplemented("ItemRowModel.onDuplicate")
   var onTap: () -> Void = unimplemented("ItemRowModel.onTap")
 
-  var id: Item.ID { self.item.id }
+  var id: Item.ID { item.id }
 
   init(item: Item) {
     self.item = item
   }
 
   func deleteButtonTapped() {
-    self.destination = .alert(
+    destination = .alert(
       AlertState {
-        TextState(self.item.name)
+        TextState(item.name)
       } actions: {
         ButtonState(role: .destructive, action: .send(.deleteConfirmation, animation: .default)) {
           TextState("Delete")
@@ -44,33 +44,33 @@ class ItemRowModel: Identifiable {
   func alertButtonTapped(_ action: AlertAction?) {
     switch action {
     case .deleteConfirmation?:
-      self.onDelete()
+      onDelete()
     case nil:
       break
     }
   }
 
   func cancelButtonTapped() {
-    self.destination = nil
+    destination = nil
   }
 
   func duplicateButtonTapped() {
-    self.destination = .duplicate(self.item.duplicate())
+    destination = .duplicate(item.duplicate())
   }
 
   func duplicate(item: Item) {
-    self.onDuplicate(item)
-    self.destination = nil
+    onDuplicate(item)
+    destination = nil
   }
 
   func rowTapped() {
-    self.onTap()
+    onTap()
   }
 }
 
 extension Item {
   func duplicate() -> Self {
-    Self(color: self.color, name: self.name, status: self.status)
+    Self(color: color, name: name, status: status)
   }
 }
 
@@ -79,14 +79,14 @@ struct ItemRowView: View {
 
   var body: some View {
     Button {
-      self.model.rowTapped()
+      model.rowTapped()
     } label: {
       HStack {
         VStack(alignment: .leading) {
-          Text(self.model.item.name)
+          Text(model.item.name)
             .font(.title3)
 
-          switch self.model.item.status {
+          switch model.item.status {
           case let .inStock(quantity):
             Text("In stock: \(quantity)")
           case let .outOfStock(isOnBackOrder):
@@ -96,41 +96,41 @@ struct ItemRowView: View {
 
         Spacer()
 
-        if let color = self.model.item.color {
+        if let color = model.item.color {
           Rectangle()
             .frame(width: 30, height: 30)
             .foregroundColor(color.swiftUIColor)
             .border(Color.black, width: 1)
         }
 
-        Button(action: { self.model.duplicateButtonTapped() }) {
+        Button(action: { model.duplicateButtonTapped() }) {
           Image(systemName: "square.fill.on.square.fill")
         }
         .padding(.leading)
 
-        Button(action: { self.model.deleteButtonTapped() }) {
+        Button(action: { model.deleteButtonTapped() }) {
           Image(systemName: "trash.fill")
         }
         .padding(.leading)
       }
       .buttonStyle(.plain)
-      .foregroundColor(self.model.item.status.is(\.inStock) ? nil : Color.gray)
-      .alert(self.$model.destination.alert) {
-        self.model.alertButtonTapped($0)
+      .foregroundColor(model.item.status.is(\.inStock) ? nil : Color.gray)
+      .alert($model.destination.alert) {
+        model.alertButtonTapped($0)
       }
-      .popover(unwrapping: self.$model.destination.duplicate) { $item in
+      .popover(item: $model.destination.duplicate) { $item in
         NavigationStack {
           ItemView(item: $item)
             .navigationBarTitle("Duplicate")
             .toolbar {
               ToolbarItem(placement: .cancellationAction) {
                 Button("Cancel") {
-                  self.model.cancelButtonTapped()
+                  model.cancelButtonTapped()
                 }
               }
               ToolbarItem(placement: .primaryAction) {
                 Button("Add") {
-                  self.model.duplicate(item: item)
+                  model.duplicate(item: item)
                 }
               }
             }

--- a/Sources/SwiftUINavigation/Documentation.docc/Articles/Bindings.md
+++ b/Sources/SwiftUINavigation/Documentation.docc/Articles/Bindings.md
@@ -4,7 +4,7 @@ Learn how to manage certain view state, such as `@FocusState` directly in your o
 
 ## Overview
 
-SwiftUI comes with many property wrappers that can be used in views to drive view state, such as 
+SwiftUI comes with many property wrappers that can be used in views to drive view state, such as
 
 `@FocusState`. Unfortunately, these property wrappers _must_ be used in views. It's not possible to
 extract this logic to an `@Observable` class and integrate it with the rest of the model's business
@@ -38,7 +38,7 @@ Notice that we store the focus as a regular `var` property in the model rather t
 This is because `@FocusState` only works when installed directly in a view. It cannot be used in
 an observable class.
 
-You can implement the view as you would normally, except you must also use `@FocusState` for the 
+You can implement the view as you would normally, except you must also use `@FocusState` for the
 focus _and_ use the `bind` helper to make sure that changes to the model's focus are replayed to
 the view, and vice versa.
 

--- a/Sources/SwiftUINavigation/Documentation.docc/Articles/Navigation.md
+++ b/Sources/SwiftUINavigation/Documentation.docc/Articles/Navigation.md
@@ -9,7 +9,7 @@ The library comes with new tools for driving drill-down navigation with optional
 This includes new initializers on `NavigationLink` and new overloads of the `navigationDestination`
 view modifier.
 
-Suppose your view or model holds a piece of optional state that represents whether or not a 
+Suppose your view or model holds a piece of optional state that represents whether or not a
 drill-down should occur:
 
 ```swift
@@ -20,14 +20,14 @@ struct ContentView: View {
 }
 ```
 
-Further suppose that the screen being navigated to wants a binding to the integer when it is 
-non-`nil`. You can construct a `NavigationLink` that will activate when that state becomes 
+Further suppose that the screen being navigated to wants a binding to the integer when it is
+non-`nil`. You can construct a `NavigationLink` that will activate when that state becomes
 non-`nil`, and will deactivate when the state becomes `nil`:
 
 ```swift
-NavigationLink(unwrapping: self.$destination) { isActive in
-  self.destination = isActive ? 42 : nil
-} destination: { $number in 
+NavigationLink(unwrapping: $destination) { isActive in
+  destination = isActive ? 42 : nil
+} destination: { $number in
   CounterView(number: $number)
 } label: {
   Text("Go to counter")
@@ -46,13 +46,11 @@ For iOS 16+ you can use the `navigationDestination` overload:
 
 ```swift
 Button {
-  self.destination = 42
+  destination = 42
 } label: {
   Text("Go to counter")
 }
-.navigationDestination(
-  unwrapping: self.$model.destination
-) { $item in 
+.navigationDestination(item: $model.destination) { $item in
   CounterView(number: $number)
 }
 ```
@@ -60,7 +58,7 @@ Button {
 Sometimes it is not optimal to model navigation destinations as optionals. In particular, if a
 feature can navigate to multiple, mutually exclusive screens, then an enum is more appropriate.
 
-Suppose that in addition to be able to drill down to a counter view that one can also open a 
+Suppose that in addition to be able to drill down to a counter view that one can also open a
 sheet with some text. We can model those destinations as an enum:
 
 ```swift
@@ -88,9 +86,9 @@ With this set up you can make use of the
 which case of the enum you want driving navigation:
 
 ```swift
-NavigationLink(unwrapping: self.$destination.counter) { isActive in
-  self.destination = isActive ? .counter(42) : nil
-} destination: { $number in 
+NavigationLink(unwrapping: $destination.counter) { isActive in
+  destination = isActive ? .counter(42) : nil
+} destination: { $number in
   CounterView(number: $number)
 } label: {
   Text("Go to counter")
@@ -101,11 +99,11 @@ And similarly for ``SwiftUI/View/navigationDestination(unwrapping:destination:)`
 
 ```swift
 Button {
-  self.destination = .counter(42)
+  destination = .counter(42)
 } label: {
   Text("Go to counter")
 }
-.navigationDestination(unwrapping: self.$model.destination.counter) { $number in 
+.navigationDestination(unwrapping: $model.destination.counter) { $number in
   CounterView(number: $number)
 }
 ```
@@ -114,7 +112,7 @@ Button {
 
 ### Navigation views and modifiers
 
-- ``SwiftUI/View/navigationDestination(unwrapping:destination:)``
+- ``SwiftUI/View/navigationDestination(item:destination:)``
 - ``SwiftUI/NavigationLink/init(unwrapping:onNavigate:destination:label:)``
 
 ### Supporting types

--- a/Sources/SwiftUINavigation/Documentation.docc/Articles/SheetsPopoversCovers.md
+++ b/Sources/SwiftUINavigation/Documentation.docc/Articles/SheetsPopoversCovers.md
@@ -4,7 +4,7 @@ Learn how to present sheets, popovers and covers in a concise and testable manne
 
 ## Overview
 
-The library comes with new tools for driving sheets, popovers and covers from optional and enum 
+The library comes with new tools for driving sheets, popovers and covers from optional and enum
 state.
 
 * [Sheets](#Sheets)
@@ -25,14 +25,14 @@ struct ContentView: View {
 ```
 
 Further suppose that the screen being presented wants a binding to the integer when it is non-`nil`.
-You can use the `sheet(unwrapping:)` view modifier that comes with the library:
+You can use the `sheet(item:)` overload that comes with the library:
 
 ```swift
 var body: some View {
   List {
     // ...
   }
-  .sheet(unwrapping: self.$destination) { $number in 
+  .sheet(item: $destination) { $number in
     CounterView(number: $number)
   }
 }
@@ -42,7 +42,7 @@ Notice that the trailing closure is handed a binding to the unwrapped state. Thi
 handed to the child view, and any changes made by the parent will be reflected in the child, and
 vice-versa.
 
-Sometimes it is not optimal to model presentation destinations as optionals. In particular, if a 
+Sometimes it is not optimal to model presentation destinations as optionals. In particular, if a
 feature can navigate to multiple, mutually exclusive screens, then an enum is more appropriate.
 
 There is an additional overload of the `sheet` for this situation. If you model your destinations
@@ -65,7 +65,7 @@ var body: some View {
   List {
     // ...
   }
-  .sheet(unwrapping: self.$destination.counter) { $number in 
+  .sheet(item: $destination.counter) { $number in
     CounterView(number: $number)
   }
 }
@@ -84,7 +84,7 @@ struct ContentView: View {
     List {
       // ...
     }
-    .popover(unwrapping: self.$destination) { $number in 
+    .popover(item: $destination) { $number in
       CounterView(number: $number)
     }
   }
@@ -107,7 +107,7 @@ struct ContentView: View {
     List {
       // ...
     }
-    .popover(unwrapping: self.$destination.counter) { $number in 
+    .popover(item: $destination.counter) { $number in
       CounterView(number: $number)
     }
   }
@@ -127,7 +127,7 @@ struct ContentView: View {
     List {
       // ...
     }
-    .fullscreenCover(unwrapping: self.$destination) { $number in 
+    .fullscreenCover(item: $destination) { $number in
       CounterView(number: $number)
     }
   }
@@ -150,7 +150,7 @@ struct ContentView: View {
     List {
       // ...
     }
-    .fullscreenCover(unwrapping: self.$destination.counter) { $number in 
+    .fullscreenCover(item: $destination.counter) { $number in
       CounterView(number: $number)
     }
   }
@@ -161,6 +161,12 @@ struct ContentView: View {
 
 ### Presentation modifiers
 
-- ``SwiftUI/View/fullScreenCover(unwrapping:onDismiss:content:)``
-- ``SwiftUI/View/popover(unwrapping:attachmentAnchor:arrowEdge:content:)``
-- ``SwiftUI/View/sheet(unwrapping:onDismiss:content:)``
+- ``SwiftUI/View/fullScreenCover(item:id:onDismiss:content:)-9csbq``
+- ``SwiftUI/View/fullScreenCover(item:onDismiss:content:)``
+- ``SwiftUI/View/fullScreenCover(item:id:onDismiss:content:)-14to1``
+- ``SwiftUI/View/popover(item:id:attachmentAnchor:arrowEdge:content:)-3un96``
+- ``SwiftUI/View/popover(item:attachmentAnchor:arrowEdge:content:)``
+- ``SwiftUI/View/popover(item:id:attachmentAnchor:arrowEdge:content:)-57svy``
+- ``SwiftUI/View/sheet(item:id:onDismiss:content:)-1hi9l``
+- ``SwiftUI/View/sheet(item:onDismiss:content:)``
+- ``SwiftUI/View/sheet(item:id:onDismiss:content:)-6tgux``

--- a/Sources/SwiftUINavigation/Documentation.docc/Articles/WhatIsNavigation.md
+++ b/Sources/SwiftUINavigation/Documentation.docc/Articles/WhatIsNavigation.md
@@ -1,12 +1,12 @@
 # What is navigation?
 
-Learn how one can think of navigation as a domain modeling problem, and how that leads to the 
+Learn how one can think of navigation as a domain modeling problem, and how that leads to the
 creation of concise and testable APIs for navigation.
 
 ## Overview
 
-We will define navigation as a "mode" change in an application. The most prototypical example of 
-this in SwiftUI are navigation stacks and links. A user taps a button, and a right-to-left 
+We will define navigation as a "mode" change in an application. The most prototypical example of
+this in SwiftUI are navigation stacks and links. A user taps a button, and a right-to-left
 animation transitions you from the current screen to the next screen.
 
 But there are more examples of navigation beyond that one example. Modal sheets can be thought of
@@ -15,25 +15,25 @@ new screen. Full screen covers and popovers are also an example of navigation, a
 similar to sheets except they either take over the full screen (i.e. covers) or only partially
 take over the screen (i.e. popovers).
 
-Even alerts and confirmation dialogs can be thought of navigation as they take full control over 
-the interface and force you to make a selection. It's also possible for you to define your own 
+Even alerts and confirmation dialogs can be thought of navigation as they take full control over
+the interface and force you to make a selection. It's also possible for you to define your own
 notions of navigation, such as bottom sheets, toasts, and more.
 
 ## State-driven navigation
 
-All of these seemingly disparate examples of navigation can be unified under a single API. The 
-presentation and dismissal of a screen can be described with an optional piece of state. When the 
-state changes from `nil` to non-`nil` the screen will be presented, whether that be via a 
+All of these seemingly disparate examples of navigation can be unified under a single API. The
+presentation and dismissal of a screen can be described with an optional piece of state. When the
+state changes from `nil` to non-`nil` the screen will be presented, whether that be via a
 drill-down, modal, popover, etc. And when the state changes from non-`nil` to `nil` the screen will
 be dismissed.
 
 Driving navigation from state like this can be incredibly powerful:
 
-  * It guarantees that your model will always be in sync with the visual representation of the UI. 
+  * It guarantees that your model will always be in sync with the visual representation of the UI.
     It shouldn't be possible for a piece of state to be non-`nil` and not have the corresponding
     view present.
   * It easily enables deep linking capabilities. If all forms of navigation in your application are
-    driven off of state, then you can instantly open your application into any state imaginable by 
+    driven off of state, then you can instantly open your application into any state imaginable by
     simply constructing a piece of state, handing it to SwiftUI, and letting it do its thing.
   * It also allows you to write unit tests for navigation logic without resorting to UI tests, which
     can be slow, flakey and introduce instability into your test suite. If you write a unit test
@@ -69,7 +69,7 @@ sheet for editing the item:
 class FeatureModel {
   var editingItem: Item?
   func tapped(item: Item) {
-    self.editingItem = item
+    editingItem = item
   }
   // ...
 }
@@ -79,20 +79,20 @@ struct FeatureView: View {
 
   var body: some View {
     List {
-      ForEach(self.model.items) { item in 
+      ForEach(model.items) { item in
         Button(item.name) {
-          self.model.tapped(item: item)
+          model.tapped(item: item)
         }
       }
     }
-    .sheet(item: self.$model.editingItem) { item in 
+    .sheet(item: $model.editingItem) { item in
       EditItemView(item: item)
     }
   }
 }
 ```
 
-This works really great. When the button is tapped, the `tapped(item:)` method is called on the 
+This works really great. When the button is tapped, the `tapped(item:)` method is called on the
 model causing the `editingItem` state to be hydrated, and then SwiftUI sees that value is no longer
 `nil` and so causes the sheet to be presented.
 
@@ -124,11 +124,11 @@ sheet view presented is handed a plain, inert value, and if that view wants to m
 will need to find a way to communicate that back to the parent. However, two-way communication
 is already a solved problem in SwiftUI with bindings.
 
-So, it might be better if the `sheet(item:content:)` API handed a binding to the unwrapped item so 
+So, it might be better if the `sheet(item:content:)` API handed a binding to the unwrapped item so
 that any mutations in the sheet would be instantly observable by the parent:
 
 ```swift
-.sheet(item: self.$model.editingItem) { $item in 
+.sheet(item: $model.editingItem) { $item in
   EditItemView(item: $item)
 }
 ```
@@ -139,7 +139,7 @@ The second problem is that while optional state is a great way to drive navigati
 scale to multiple navigation destinations.
 
 For example, suppose that in addition to being able to edit an item, the feature can also add an
-item and duplicate an item, and you can navigate to a help screen. That can technically be 
+item and duplicate an item, and you can navigate to a help screen. That can technically be
 represented as four optionals:
 
 ```swift
@@ -153,17 +153,17 @@ class FeatureModel {
 }
 ```
 
-But this is not the most concise way to model this domain. Four optional values means there are 
+But this is not the most concise way to model this domain. Four optional values means there are
 `2⁴=16` different states this feature can be in, but only 5 of those states are valid. Either all
-can be `nil`, representing we are not navigated anywhere, or at most one can be non-`nil`, 
+can be `nil`, representing we are not navigated anywhere, or at most one can be non-`nil`,
 representing navigation to a single screen.
 
 But it is not valid to have 2, 3 or 4 non-`nil` values. That would represent multiple screens
 being simultaneously navigated to, such as two sheets being presented, which is invalid in SwiftUI
 and can even cause crashes.
 
-This is showing that four optional values is not the best way to represent 4 navigation 
-destinations. Instead, it is more concise to model the 4 destinations as an enum with a case for 
+This is showing that four optional values is not the best way to represent 4 navigation
+destinations. Instead, it is more concise to model the 4 destinations as an enum with a case for
 each destination, and then hold onto a single optional value to represent which destination
 is currently active:
 
@@ -192,8 +192,8 @@ and more from a particular case of that enum.
 
 ## SwiftUINavigation's tools
 
-The tools that ship with this library aim to solve the problems discussed above, and more. There are 
-new APIs for sheets, popovers, covers, alerts, confirmation dialogs _and_ navigation links that 
+The tools that ship with this library aim to solve the problems discussed above, and more. There are
+new APIs for sheets, popovers, covers, alerts, confirmation dialogs _and_ navigation links that
 allow you to model destinations as an enum and drive navigation by a particular case of the enum.
 
 All of the APIs for these seemingly disparate forms of navigation are unified by a single pattern.
@@ -203,9 +203,9 @@ content that takes a binding to a non-optional value.
 For example, the new sheet API now takes a binding to an optional:
 
 ```swift
-func sheet<Value, Content: View>(
-  unwrapping: Binding<Value?>,
-  content: @escaping (Binding<Value>) -> Content
+func sheet<Item: Hashable, Content: View>(
+  item: Binding<Item?>,
+  content: @escaping (Binding<Item>) -> Content
 ) -> some View
 ```
 
@@ -214,9 +214,9 @@ optional value, but also from a particular case of an enum.
 
 In order to isolate a specific case of an enum we make use of our [CasePaths][case-paths-gh]
 library. A case path is like a key path, except it is specifically tuned for abstracting over the
-shape of enums rather than structs. A key path abstractly bundles up the functionality of getting 
+shape of enums rather than structs. A key path abstractly bundles up the functionality of getting
 and setting a property on a struct, whereas a case path bundles up the functionality of "extracting"
-a value from an enum and "embedding" a value into an enum. They are an indispensable tool for 
+a value from an enum and "embedding" a value into an enum. They are an indispensable tool for
 transforming bindings.
 
 Similar APIs are defined for popovers, covers, and more.
@@ -246,13 +246,13 @@ shown in a popover, and the `edit` destination in a drill-down. We can do so eas
 that ship with this library:
 
 ```swift
-.popover(unwrapping: self.$model.destination.duplicate) { $item in 
+.popover(item: $model.destination.duplicate) { $item in
   DuplicateItemView(item: $item)
 }
-.sheet(unwrapping: self.$model.destination.add) { $item in 
+.sheet(item: $model.destination.add) { $item in
   AddItemView(item: $item)
 }
-.navigationDestination(unwrapping: self.$model.destination.edit) { $item in
+.navigationDestination(item: $model.destination.edit) { $item in
   EditItemView(item: $item)
 }
 ```
@@ -266,9 +266,9 @@ later. If you must support iOS 15 and earlier, you can use the following initial
 `NavigationLink`, which also has a very similar API to the above:
 
 ```swift
-NavigationLink(unwrapping: self.$model.destination.edit) { isActive in 
-  self.model.setEditIsActive(isActive)
-} destination: { $item in 
+NavigationLink(unwrapping: $model.destination.edit) { isActive in
+  model.setEditIsActive(isActive)
+} destination: { $item in
   EditItemView(item: $item)
 } label: {
   Text("\(item.name)")
@@ -283,7 +283,7 @@ reading the articles below.
 ### Tools
 
 Read the following articles to learn more about the tools that ship with this library for presenting
-alerts, dialogs, sheets, popovers, covers, and navigation links all from bindings of enum state. 
+alerts, dialogs, sheets, popovers, covers, and navigation links all from bindings of enum state.
 
 - <doc:Navigation>
 - <doc:SheetsPopoversCovers>

--- a/Sources/SwiftUINavigation/Documentation.docc/Extensions/Deprecations.md
+++ b/Sources/SwiftUINavigation/Documentation.docc/Extensions/Deprecations.md
@@ -20,6 +20,7 @@ instead.
 
 ### View modifiers
 
+- ``SwiftUI/View/alert(title:unwrapping:actions:message:)``
 - ``SwiftUI/View/alert(title:unwrapping:case:actions:message:)``
 - ``SwiftUI/View/alert(title:unwrapping:actions:message:)``
 - ``SwiftUI/View/alert(unwrapping:action:)-7da26``
@@ -28,6 +29,7 @@ instead.
 - ``SwiftUI/View/alert(unwrapping:case:action:)-14fwn``
 - ``SwiftUI/View/alert(unwrapping:case:action:)-3yw6u``
 - ``SwiftUI/View/alert(unwrapping:case:action:)-4w3oq``
+- ``SwiftUI/View/confirmationDialog(title:titleVisibility:unwrapping:actions:message:)``
 - ``SwiftUI/View/confirmationDialog(title:titleVisibility:unwrapping:case:actions:message:)``
 - ``SwiftUI/View/confirmationDialog(unwrapping:action:)-9465l``
 - ``SwiftUI/View/confirmationDialog(unwrapping:action:)-4f8ze``
@@ -35,9 +37,13 @@ instead.
 - ``SwiftUI/View/confirmationDialog(unwrapping:case:action:)-uncl``
 - ``SwiftUI/View/confirmationDialog(unwrapping:case:action:)-2ddxv``
 - ``SwiftUI/View/confirmationDialog(unwrapping:case:action:)-7oi9``
+- ``SwiftUI/View/fullScreenCover(unwrapping:onDismiss:content:)``
 - ``SwiftUI/View/fullScreenCover(unwrapping:case:onDismiss:content:)``
+- ``SwiftUI/View/navigationDestination(unwrapping:destination:)``
 - ``SwiftUI/View/navigationDestination(unwrapping:case:destination:)``
+- ``SwiftUI/View/popover(unwrapping:attachmentAnchor:arrowEdge:content:)``
 - ``SwiftUI/View/popover(unwrapping:case:attachmentAnchor:arrowEdge:content:)``
+- ``SwiftUI/View/sheet(unwrapping:onDismiss:content:)``
 - ``SwiftUI/View/sheet(unwrapping:case:onDismiss:content:)``
 
 ### Bindings

--- a/Sources/SwiftUINavigation/Documentation.docc/SwiftUINavigation.md
+++ b/Sources/SwiftUINavigation/Documentation.docc/SwiftUINavigation.md
@@ -10,27 +10,27 @@ Tools for making SwiftUI navigation simpler, more ergonomic and more precise.
 
 ## Overview
 
-SwiftUI comes with many forms of navigation (tabs, alerts, dialogs, modal sheets, popovers, 
-navigation links, and more), and each comes with a few ways to construct them. These ways roughly 
+SwiftUI comes with many forms of navigation (tabs, alerts, dialogs, modal sheets, popovers,
+navigation links, and more), and each comes with a few ways to construct them. These ways roughly
 fall in two categories:
 
-  * "Fire-and-forget": These are initializers and methods that do not take binding arguments, which 
-    means SwiftUI fully manages navigation state internally. This makes it is easy to get something 
-    on the screen quickly, but you also have no programmatic control over the navigation. Examples 
-    of this are the initializers on [`TabView`][TabView.init] and 
+  * "Fire-and-forget": These are initializers and methods that do not take binding arguments, which
+    means SwiftUI fully manages navigation state internally. This makes it is easy to get something
+    on the screen quickly, but you also have no programmatic control over the navigation. Examples
+    of this are the initializers on [`TabView`][TabView.init] and
     [`NavigationLink`][NavigationLink.init] that do not take a binding.
 
-  * "State-driven": Most other initializers and methods do take a binding, which means you can 
-    mutate state in your domain to tell SwiftUI when it should activate or deactivate navigation. 
-    Using these APIs is more complicated than the "fire-and-forget" style, but doing so instantly 
-    gives you the ability to deep-link into any state of your application by just constructing a 
+  * "State-driven": Most other initializers and methods do take a binding, which means you can
+    mutate state in your domain to tell SwiftUI when it should activate or deactivate navigation.
+    Using these APIs is more complicated than the "fire-and-forget" style, but doing so instantly
+    gives you the ability to deep-link into any state of your application by just constructing a
     piece of data, handing it to a SwiftUI view, and letting SwiftUI handle the rest.
 
-Navigation that is "state-driven" is the more powerful form of navigation, albeit slightly more 
+Navigation that is "state-driven" is the more powerful form of navigation, albeit slightly more
 complicated. To wield it correctly you must be able to model your domain as concisely as possible,
 and this usually means using enums.
 
-Unfortunately, SwiftUI does not ship with all of the tools necessary to model our domains with 
+Unfortunately, SwiftUI does not ship with all of the tools necessary to model our domains with
 enums and make use of navigation APIs. This library bridges that gap by providing APIs that allow
 you to model your navigation destinations as an enum, and then drive navigation by a binding
 to that enum.

--- a/Sources/SwiftUINavigation/FullScreenCover.swift
+++ b/Sources/SwiftUINavigation/FullScreenCover.swift
@@ -4,39 +4,18 @@
   @available(iOS 14, tvOS 14, watchOS 7, *)
   @available(macOS, unavailable)
   extension View {
-    /// Presents a full-screen cover using a binding as a data source for the sheet's content based
-    /// on the identity of the underlying item.
-    ///
-    /// - Parameters:
-    ///   - item: A binding to an optional source of truth for the sheet. When `item` is non-`nil`,
-    ///     the system passes the item's content to the modifier's closure. You display this content
-    ///     in a sheet that you create that the system displays to the user. If `item` changes, the
-    ///     system dismisses the sheet and replaces it with a new one using the same process.
-    ///   - id: The key path to the provided item's identifier.
-    ///   - onDismiss: The closure to execute when dismissing the sheet.
-    ///   - content: A closure returning the content of the sheet.
-    public func fullScreenCover<Item, ID: Hashable, Content: View>(
-      item: Binding<Item?>,
-      id: KeyPath<Item, ID>,
-      onDismiss: (() -> Void)? = nil,
-      @ViewBuilder content: @escaping (Item) -> Content
-    ) -> some View {
-      self.fullScreenCover(item: item[id: id], onDismiss: onDismiss) { _ in
-        item.wrappedValue.map(content)
-      }
-    }
-
     /// Presents a full-screen cover using a binding as a data source for the sheet's content.
     ///
     /// SwiftUI comes with a `fullScreenCover(item:)` view modifier that is powered by a binding to
-    /// some hashable state. When this state becomes non-`nil`, it passes an unwrapped value to the
-    /// content closure. This value, however, is completely static, which prevents the sheet from
-    /// modifying it.
+    /// some identifiable state. When this state becomes non-`nil`, it passes an unwrapped value to
+    /// the content closure. This value, however, is completely static, which prevents the sheet
+    /// from modifying it.
     ///
     /// This overload differs in that it passes a _binding_ to the unwrapped value, instead. This
     /// gives the sheet the ability to write changes back to its source of truth.
     ///
-    /// Also unlike `fullScreenCover(item:)`, the binding's value does _not_ need to be hashable.
+    /// Also unlike `fullScreenCover(item:)`, the binding's value does _not_ need to be
+    /// identifiable, and can instead specify a key path to the provided data's identifier.
     ///
     /// ```swift
     /// struct TimelineView: View {
@@ -46,7 +25,7 @@
     ///     Button("Compose") {
     ///       self.draft = Post()
     ///     }
-    ///     .fullScreenCover(unwrapping: self.$draft) { $draft in
+    ///     .fullScreenCover(item: $draft, id: \.id) { $draft in
     ///       ComposeView(post: $draft, onSubmit: { ... })
     ///     }
     ///   }
@@ -59,25 +38,70 @@
     /// ```
     ///
     /// - Parameters:
-    ///   - value: A binding to a source of truth for the sheet. When `value` is non-`nil`, a
-    ///     non-optional binding to the value is passed to the `content` closure. You use this
-    ///     binding to produce content that the system presents to the user in a sheet. Changes made
-    ///     to the sheet's binding will be reflected back in the source of truth. Likewise, changes
-    ///     to `value` are instantly reflected in the sheet. If `value` becomes `nil`, the sheet is
-    ///     dismissed.
+    ///   - item: A binding to an optional source of truth for the sheet. When `item` is non-`nil`,
+    ///     the system passes the item's content to the modifier's closure. You display this content
+    ///     in a sheet that you create that the system displays to the user. If `item`'s identity
+    ///     changes, the system dismisses the sheet and replaces it with a new one using the same
+    ///     process.
+    ///   - id: The key path to the provided item's identifier.
     ///   - onDismiss: The closure to execute when dismissing the sheet.
     ///   - content: A closure returning the content of the sheet.
-    public func fullScreenCover<Value, Content>(
-      unwrapping value: Binding<Value?>,
+    @_disfavoredOverload
+    public func fullScreenCover<Item, ID: Hashable, Content: View>(
+      item: Binding<Item?>,
+      id: KeyPath<Item, ID>,
       onDismiss: (() -> Void)? = nil,
-      @ViewBuilder content: @escaping (Binding<Value>) -> Content
-    ) -> some View
-    where Content: View {
-      self.fullScreenCover(
-        isPresented: value.isPresent(),
-        onDismiss: onDismiss
-      ) {
-        Binding(unwrapping: value).map(content)
+      @ViewBuilder content: @escaping (Binding<Item>) -> Content
+    ) -> some View {
+      fullScreenCover(item: item[id: id], onDismiss: onDismiss) { _ in
+        Binding(unwrapping: item).map(content)
+      }
+    }
+
+    /// Presents a full-screen cover using a binding as a data source for the sheet's content.
+    ///
+    /// A version of ``fullScreenCover(item:id:onDismiss:content:)-14to1`` that takes an
+    /// identifiable item.
+    ///
+    /// - Parameters:
+    ///   - item: A binding to an optional source of truth for the sheet. When `item` is non-`nil`,
+    ///     the system passes the item's content to the modifier's closure. You display this content
+    ///     in a sheet that you create that the system displays to the user. If `item`'s identity
+    ///     changes, the system dismisses the sheet and replaces it with a new one using the same
+    ///     process.
+    ///   - onDismiss: The closure to execute when dismissing the sheet.
+    ///   - content: A closure returning the content of the sheet.
+    @_disfavoredOverload
+    public func fullScreenCover<Item: Identifiable, Content: View>(
+      item: Binding<Item?>,
+      onDismiss: (() -> Void)? = nil,
+      @ViewBuilder content: @escaping (Binding<Item>) -> Content
+    ) -> some View {
+      fullScreenCover(item: item, id: \.id, onDismiss: onDismiss, content: content)
+    }
+
+    /// Presents a full-screen cover using a binding as a data source for the sheet's content.
+    ///
+    /// A version of ``fullScreenCover(item:id:onDismiss:content:)-14to1`` that is passed an item
+    /// and not a binding to an item.
+    ///
+    /// - Parameters:
+    ///   - item: A binding to an optional source of truth for the sheet. When `item` is non-`nil`,
+    ///     the system passes the item's content to the modifier's closure. You display this content
+    ///     in a sheet that you create that the system displays to the user. If `item`'s identity
+    ///     changes, the system dismisses the sheet and replaces it with a new one using the same
+    ///     process.
+    ///   - id: The key path to the provided item's identifier.
+    ///   - onDismiss: The closure to execute when dismissing the sheet.
+    ///   - content: A closure returning the content of the sheet.
+    public func fullScreenCover<Item, ID: Hashable, Content: View>(
+      item: Binding<Item?>,
+      id: KeyPath<Item, ID>,
+      onDismiss: (() -> Void)? = nil,
+      @ViewBuilder content: @escaping (Item) -> Content
+    ) -> some View {
+      fullScreenCover(item: item, id: id, onDismiss: onDismiss) {
+        content($0.wrappedValue)
       }
     }
   }

--- a/Sources/SwiftUINavigation/Internal/Deprecations.swift
+++ b/Sources/SwiftUINavigation/Internal/Deprecations.swift
@@ -2,6 +2,122 @@
   import SwiftUI
   @_spi(RuntimeWarn) import SwiftUINavigationCore
 
+  // NB: Deprecated after 1.3.0
+
+  @available(iOS 14, tvOS 14, watchOS 7, *)
+  @available(macOS, unavailable)
+  extension View {
+    @available(
+      *, deprecated,
+      message:
+        "Use the 'fullScreenCover(item:)' (or 'fullScreenCover(item:id:)') overload that passes a binding"
+    )
+    public func fullScreenCover<Value, Content>(
+      unwrapping value: Binding<Value?>,
+      onDismiss: (() -> Void)? = nil,
+      @ViewBuilder content: @escaping (Binding<Value>) -> Content
+    ) -> some View
+    where Content: View {
+      self.fullScreenCover(
+        isPresented: value.isPresent(),
+        onDismiss: onDismiss
+      ) {
+        Binding(unwrapping: value).map(content)
+      }
+    }
+  }
+
+  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+  extension View {
+    @available(
+      *, deprecated,
+      message: "Use the 'navigationDestination(item:)' overload that passes a binding"
+    )
+    @ViewBuilder
+    public func navigationDestination<Value, Destination: View>(
+      unwrapping value: Binding<Value?>,
+      @ViewBuilder destination: (Binding<Value>) -> Destination
+    ) -> some View {
+      if requiresBindWorkaround {
+        self.modifier(
+          _NavigationDestinationBindWorkaround(
+            isPresented: value.isPresent(),
+            destination: Binding(unwrapping: value).map(destination)
+          )
+        )
+      } else {
+        self.navigationDestination(isPresented: value.isPresent()) {
+          Binding(unwrapping: value).map(destination)
+        }
+      }
+    }
+  }
+
+  // NB: This view modifier works around a bug in SwiftUI's built-in modifier:
+  // https://gist.github.com/mbrandonw/f8b94957031160336cac6898a919cbb7#file-fb11056434-md
+  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+  private struct _NavigationDestinationBindWorkaround<Destination: View>: ViewModifier {
+    @Binding var isPresented: Bool
+    let destination: Destination
+
+    @State private var isPresentedState = false
+
+    public func body(content: Content) -> some View {
+      content
+        .navigationDestination(isPresented: self.$isPresentedState) { self.destination }
+        .bind(self.$isPresented, to: self.$isPresentedState)
+    }
+  }
+
+  private let requiresBindWorkaround = {
+    if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
+      return true
+    }
+    guard #available(iOS 16.4, macOS 13.3, tvOS 16.4, watchOS 9.4, *)
+    else { return true }
+    return false
+  }()
+
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
+  extension View {
+    @available(
+      *, deprecated,
+      message: "Use the 'popover(item:)' (or 'popover(item:id:)') overload that passes a binding"
+    )
+    public func popover<Value, Content: View>(
+      unwrapping value: Binding<Value?>,
+      attachmentAnchor: PopoverAttachmentAnchor = .rect(.bounds),
+      arrowEdge: Edge = .top,
+      @ViewBuilder content: @escaping (Binding<Value>) -> Content
+    ) -> some View {
+      self.popover(
+        isPresented: value.isPresent(),
+        attachmentAnchor: attachmentAnchor,
+        arrowEdge: arrowEdge
+      ) {
+        Binding(unwrapping: value).map(content)
+      }
+    }
+  }
+
+  extension View {
+    @available(
+      *, deprecated,
+      message: "Use the 'sheet(item:)' (or 'sheet(item:id:)') overload that passes a binding"
+    )
+    public func sheet<Value, Content>(
+      unwrapping value: Binding<Value?>,
+      onDismiss: (() -> Void)? = nil,
+      @ViewBuilder content: @escaping (Binding<Value>) -> Content
+    ) -> some View
+    where Content: View {
+      self.sheet(isPresented: value.isPresent(), onDismiss: onDismiss) {
+        Binding(unwrapping: value).map(content)
+      }
+    }
+  }
+
   // NB: Deprecated after 1.2.1
 
   @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
@@ -116,24 +232,10 @@
     }
   }
 
+  @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
   extension View {
     @available(
-      iOS, introduced: 15, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      macOS, introduced: 12, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      tvOS, introduced: 15, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      watchOS, introduced: 8, deprecated: 9999,
+      *, deprecated,
       message:
         "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
     )
@@ -153,22 +255,7 @@
     }
 
     @available(
-      iOS, introduced: 15, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      macOS, introduced: 12, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      tvOS, introduced: 15, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      watchOS, introduced: 8, deprecated: 9999,
+      *, deprecated,
       message:
         "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
     )
@@ -181,22 +268,7 @@
     }
 
     @available(
-      iOS, introduced: 15, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      macOS, introduced: 12, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      tvOS, introduced: 15, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      watchOS, introduced: 8, deprecated: 9999,
+      *, deprecated,
       message:
         "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
     )
@@ -209,22 +281,7 @@
     }
 
     @available(
-      iOS, introduced: 15, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      macOS, introduced: 12, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      tvOS, introduced: 15, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      watchOS, introduced: 8, deprecated: 9999,
+      *, deprecated,
       message:
         "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
     )
@@ -246,22 +303,7 @@
     }
 
     @available(
-      iOS, introduced: 15, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      macOS, introduced: 12, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      tvOS, introduced: 15, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      watchOS, introduced: 8, deprecated: 9999,
+      *, deprecated,
       message:
         "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
     )
@@ -277,22 +319,7 @@
     }
 
     @available(
-      iOS, introduced: 15, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      macOS, introduced: 12, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      tvOS, introduced: 15, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      watchOS, introduced: 8, deprecated: 9999,
+      *, deprecated,
       message:
         "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
     )
@@ -306,20 +333,13 @@
         action: handler
       )
     }
+  }
 
+  @available(macOS, unavailable)
+  @available(iOS 14, tvOS 14, watchOS 8, *)
+  extension View {
     @available(
-      iOS, introduced: 14, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(macOS, unavailable)
-    @available(
-      tvOS, introduced: 14, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      watchOS, introduced: 7, deprecated: 9999,
+      *, deprecated,
       message:
         "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
     )
@@ -333,24 +353,12 @@
       fullScreenCover(
         unwrapping: `enum`.case(casePath), onDismiss: onDismiss, content: content)
     }
+  }
 
+  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+  extension View {
     @available(
-      iOS, introduced: 16, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      macOS, introduced: 13, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      tvOS, introduced: 16, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      watchOS, introduced: 9, deprecated: 9999,
+      *, deprecated,
       message:
         "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
     )
@@ -361,19 +369,16 @@
     ) -> some View {
       navigationDestination(unwrapping: `enum`.case(casePath), destination: destination)
     }
+  }
 
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
+  extension View {
     @available(
-      iOS, introduced: 13, deprecated: 9999,
+      *, deprecated,
       message:
         "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
     )
-    @available(
-      macOS, introduced: 10.15, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(tvOS, unavailable)
-    @available(watchOS, unavailable)
     public func popover<Enum, Case, Content>(
       unwrapping enum: Binding<Enum?>,
       case casePath: AnyCasePath<Enum, Case>,
@@ -390,22 +395,7 @@
     }
 
     @available(
-      iOS, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      macOS, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      tvOS, deprecated: 9999,
-      message:
-        "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
-    )
-    @available(
-      watchOS, deprecated: 9999,
+      *, deprecated,
       message:
         "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
     )

--- a/Sources/SwiftUINavigation/NavigationDestination.swift
+++ b/Sources/SwiftUINavigation/NavigationDestination.swift
@@ -6,9 +6,8 @@
     /// Pushes a view onto a `NavigationStack` using a binding as a data source for the
     /// destination's content.
     ///
-    /// This is a version of SwiftUI's `navigationDestination(isPresented:)` modifier, but powered
-    /// by a binding to optional state instead of a binding to a boolean. When state becomes
-    /// non-`nil`, a _binding_ to the unwrapped value is passed to the destination closure.
+    /// This is a version of SwiftUI's `navigationDestination(item:)` modifier that passes a
+    /// _binding_ to the unwrapped item to the destination closure.
     ///
     /// ```swift
     /// struct TimelineView: View {
@@ -18,7 +17,7 @@
     ///     Button("Compose") {
     ///       self.draft = Post()
     ///     }
-    ///     .navigationDestination(unwrapping: self.$draft) { $draft in
+    ///     .navigationDestination(unwrapping: $draft) { $draft in
     ///       ComposeView(post: $draft, onSubmit: { ... })
     ///     }
     ///   }
@@ -31,55 +30,21 @@
     /// ```
     ///
     /// - Parameters:
-    ///   - value: A binding to an optional source of truth for the destination. When `value` is
+    ///   - item: A binding to an optional source of truth for the destination. When `item` is
     ///     non-`nil`, a non-optional binding to the value is passed to the `destination` closure.
     ///     You use this binding to produce content that the system pushes to the user in a
     ///     navigation stack. Changes made to the destination's binding will be reflected back in
-    ///     the source of truth. Likewise, changes to `value` are instantly reflected in the
-    ///     destination. If `value` becomes `nil`, the destination is popped.
+    ///     the source of truth. Likewise, changes to `item` are instantly reflected in the
+    ///     destination. If `item` becomes `nil`, the destination is popped.
     ///   - destination: A closure returning the content of the destination.
-    @ViewBuilder
-    public func navigationDestination<Value, Destination: View>(
-      unwrapping value: Binding<Value?>,
-      @ViewBuilder destination: (Binding<Value>) -> Destination
+    @_disfavoredOverload
+    public func navigationDestination<D, C: View>(
+      item: Binding<D?>,
+      @ViewBuilder destination: @escaping (Binding<D>) -> C
     ) -> some View {
-      if requiresBindWorkaround {
-        self.modifier(
-          _NavigationDestinationBindWorkaround(
-            isPresented: value.isPresent(),
-            destination: Binding(unwrapping: value).map(destination)
-          )
-        )
-      } else {
-        self.navigationDestination(isPresented: value.isPresent()) {
-          Binding(unwrapping: value).map(destination)
-        }
+      navigationDestination(item: item) { _ in
+        Binding(unwrapping: item).map(destination)
       }
     }
   }
-
-  // NB: This view modifier works around a bug in SwiftUI's built-in modifier:
-  // https://gist.github.com/mbrandonw/f8b94957031160336cac6898a919cbb7#file-fb11056434-md
-  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
-  private struct _NavigationDestinationBindWorkaround<Destination: View>: ViewModifier {
-    @Binding var isPresented: Bool
-    let destination: Destination
-
-    @State private var isPresentedState = false
-
-    public func body(content: Content) -> some View {
-      content
-        .navigationDestination(isPresented: self.$isPresentedState) { self.destination }
-        .bind(self.$isPresented, to: self.$isPresentedState)
-    }
-  }
-
-  private let requiresBindWorkaround = {
-    if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
-      return true
-    }
-    guard #available(iOS 16.4, macOS 13.3, tvOS 16.4, watchOS 9.4, *)
-    else { return true }
-    return false
-  }()
 #endif  // canImport(SwiftUI)

--- a/Sources/SwiftUINavigation/Popover.swift
+++ b/Sources/SwiftUINavigation/Popover.swift
@@ -4,8 +4,107 @@
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
   extension View {
+    /// Presents a popover using a binding as a data source for the popover's content.
+    ///
+    /// SwiftUI comes with a `popover(item:)` view modifier that is powered by a binding to some
+    /// identifiable state. When this state becomes non-`nil`, it passes an unwrapped value to the
+    /// content closure. This value, however, is completely static, which prevents the popover from
+    /// modifying it.
+    ///
+    /// This overload differs in that it passes a _binding_ to the unwrapped value, instead. This
+    /// gives the popover the ability to write changes back to its source of truth.
+    ///
+    /// Also unlike `popover(item:)`, the binding's value does _not_ need to be identifiable, and
+    /// can instead specify a key path to the provided data's identifier.
+    ///
+    /// ```swift
+    /// struct TimelineView: View {
+    ///   @State var draft: Post?
+    ///
+    ///   var body: Body {
+    ///     Button("Compose") {
+    ///       self.draft = Post()
+    ///     }
+    ///     .popover(unwrapping: $draft) { $draft in
+    ///       ComposeView(post: $draft, onSubmit: { ... })
+    ///     }
+    ///   }
+    /// }
+    ///
+    /// struct ComposeView: View {
+    ///   @Binding var post: Post
+    ///   var body: some View { ... }
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - item: A binding to an optional source of truth for the popover. When `item` is
+    ///     non-`nil`, a non-optional binding to the value is passed to the `content` closure. You
+    ///     use this binding to produce content that the system presents to the user in a popover.
+    ///     Changes made to the popover's binding will be reflected back in the source of truth.
+    ///     Likewise, changes to `item` are instantly reflected in the popover. If `item` becomes
+    ///     `nil`, the popover is dismissed.
+    ///   - id: The key path to the provided item's identifier.
+    ///   - attachmentAnchor: The positioning anchor that defines the attachment point of the
+    ///     popover.
+    ///   - arrowEdge: The edge of the `attachmentAnchor` that defines the location of the popover's
+    ///     arrow.
+    ///   - content: A closure returning the content of the popover.
+    @_disfavoredOverload
+    public func popover<Item, ID: Hashable, Content: View>(
+      item: Binding<Item?>,
+      id: KeyPath<Item, ID>,
+      attachmentAnchor: PopoverAttachmentAnchor = .rect(.bounds),
+      arrowEdge: Edge = .top,
+      @ViewBuilder content: @escaping (Binding<Item>) -> Content
+    ) -> some View {
+      popover(
+        item: item[id: id],
+        attachmentAnchor: attachmentAnchor,
+        arrowEdge: arrowEdge
+      ) { _ in
+        Binding(unwrapping: item).map(content)
+      }
+    }
+
+    /// Presents a full-screen cover using a binding as a data source for the sheet's content.
+    ///
+    /// A version of ``fullScreenCover(item:id:onDismiss:content:)-14to1`` that takes an
+    /// identifiable item.
+    ///
+    /// - Parameters:
+    ///   - item: A binding to an optional source of truth for the popover. When `item` is
+    ///     non-`nil`, a non-optional binding to the value is passed to the `content` closure. You
+    ///     use this binding to produce content that the system presents to the user in a popover.
+    ///     Changes made to the popover's binding will be reflected back in the source of truth.
+    ///     Likewise, changes to `item` are instantly reflected in the popover. If `item` becomes
+    ///     `nil`, the popover is dismissed.
+    ///   - attachmentAnchor: The positioning anchor that defines the attachment point of the
+    ///     popover.
+    ///   - arrowEdge: The edge of the `attachmentAnchor` that defines the location of the popover's
+    ///     arrow.
+    ///   - content: A closure returning the content of the popover.
+    @_disfavoredOverload
+    public func popover<Item: Identifiable, Content: View>(
+      item: Binding<Item?>,
+      attachmentAnchor: PopoverAttachmentAnchor = .rect(.bounds),
+      arrowEdge: Edge = .top,
+      @ViewBuilder content: @escaping (Binding<Item>) -> Content
+    ) -> some View {
+      popover(
+        item: item,
+        id: \.id,
+        attachmentAnchor: attachmentAnchor,
+        arrowEdge: arrowEdge,
+        content: content
+      )
+    }
+
     /// Presents a popover using a binding as a data source for the sheet's content based on the
     /// identity of the underlying item.
+    ///
+    /// A version of ``popover(item:id:attachmentAnchor:arrowEdge:content:)-3un96`` that is passed
+    /// an item and not a binding to an item.
     ///
     /// - Parameters:
     ///   - item: A binding to an optional source of truth for the popover. When `item` is
@@ -26,71 +125,8 @@
       arrowEdge: Edge = .top,
       @ViewBuilder content: @escaping (Item) -> Content
     ) -> some View {
-      self.popover(
-        item: item[id: id],
-        attachmentAnchor: attachmentAnchor,
-        arrowEdge: arrowEdge
-      ) { _ in
-        item.wrappedValue.map(content)
-      }
-    }
-
-    /// Presents a popover using a binding as a data source for the popover's content.
-    ///
-    /// SwiftUI comes with a `popover(item:)` view modifier that is powered by a binding to some
-    /// hashable state. When this state becomes non-`nil`, it passes an unwrapped value to the
-    /// content closure. This value, however, is completely static, which prevents the popover from
-    /// modifying it.
-    ///
-    /// This overload differs in that it passes a _binding_ to the unwrapped value, instead. This
-    /// gives the popover the ability to write changes back to its source of truth.
-    ///
-    /// Also unlike `popover(item:)`, the binding's value does _not_ need to be hashable.
-    ///
-    /// ```swift
-    /// struct TimelineView: View {
-    ///   @State var draft: Post?
-    ///
-    ///   var body: Body {
-    ///     Button("Compose") {
-    ///       self.draft = Post()
-    ///     }
-    ///     .popover(unwrapping: self.$draft) { $draft in
-    ///       ComposeView(post: $draft, onSubmit: { ... })
-    ///     }
-    ///   }
-    /// }
-    ///
-    /// struct ComposeView: View {
-    ///   @Binding var post: Post
-    ///   var body: some View { ... }
-    /// }
-    /// ```
-    ///
-    /// - Parameters:
-    ///   - value: A binding to an optional source of truth for the popover. When `value` is
-    ///     non-`nil`, a non-optional binding to the value is passed to the `content` closure. You
-    ///     use this binding to produce content that the system presents to the user in a popover.
-    ///     Changes made to the popover's binding will be reflected back in the source of truth.
-    ///     Likewise, changes to `value` are instantly reflected in the popover. If `value` becomes
-    ///     `nil`, the popover is dismissed.
-    ///   - attachmentAnchor: The positioning anchor that defines the attachment point of the
-    ///     popover.
-    ///   - arrowEdge: The edge of the `attachmentAnchor` that defines the location of the popover's
-    ///     arrow.
-    ///   - content: A closure returning the content of the popover.
-    public func popover<Value, Content: View>(
-      unwrapping value: Binding<Value?>,
-      attachmentAnchor: PopoverAttachmentAnchor = .rect(.bounds),
-      arrowEdge: Edge = .top,
-      @ViewBuilder content: @escaping (Binding<Value>) -> Content
-    ) -> some View {
-      self.popover(
-        isPresented: value.isPresent(),
-        attachmentAnchor: attachmentAnchor,
-        arrowEdge: arrowEdge
-      ) {
-        Binding(unwrapping: value).map(content)
+      popover(item: item, id: id, attachmentAnchor: attachmentAnchor, arrowEdge: arrowEdge) {
+        content($0.wrappedValue)
       }
     }
   }

--- a/Sources/SwiftUINavigation/Popover.swift
+++ b/Sources/SwiftUINavigation/Popover.swift
@@ -1,8 +1,7 @@
 #if canImport(SwiftUI)
   import SwiftUI
 
-  @available(tvOS, unavailable)
-  @available(watchOS, unavailable)
+  // NB: Moving `@available(tvOS, unavailable)` to the extension causes tvOS builds to fail
   extension View {
     /// Presents a popover using a binding as a data source for the popover's content.
     ///
@@ -51,6 +50,8 @@
     ///     arrow.
     ///   - content: A closure returning the content of the popover.
     @_disfavoredOverload
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
     public func popover<Item, ID: Hashable, Content: View>(
       item: Binding<Item?>,
       id: KeyPath<Item, ID>,
@@ -85,6 +86,8 @@
     ///     arrow.
     ///   - content: A closure returning the content of the popover.
     @_disfavoredOverload
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
     public func popover<Item: Identifiable, Content: View>(
       item: Binding<Item?>,
       attachmentAnchor: PopoverAttachmentAnchor = .rect(.bounds),
@@ -118,6 +121,8 @@
     ///   - arrowEdge: The edge of the `attachmentAnchor` that defines the location of the popover's
     ///     arrow.
     ///   - content: A closure returning the content of the popover.
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
     public func popover<Item, ID: Hashable, Content: View>(
       item: Binding<Item?>,
       id: KeyPath<Item, ID>,

--- a/Sources/SwiftUINavigation/Sheet.swift
+++ b/Sources/SwiftUINavigation/Sheet.swift
@@ -8,39 +8,18 @@
   #endif
 
   extension View {
-    /// Presents a sheet using a binding as a data source for the sheet's content based on the
-    /// identity of the underlying item.
-    ///
-    /// - Parameters:
-    ///   - item: A binding to an optional source of truth for the sheet. When `item` is non-`nil`,
-    ///     the system passes the item's content to the modifier's closure. You display this content
-    ///     in a sheet that you create that the system displays to the user. If `item` changes, the
-    ///     system dismisses the sheet and replaces it with a new one using the same process.
-    ///   - id: The key path to the provided item's identifier.
-    ///   - onDismiss: The closure to execute when dismissing the sheet.
-    ///   - content: A closure returning the content of the sheet.
-    public func sheet<Item, ID: Hashable, Content: View>(
-      item: Binding<Item?>,
-      id: KeyPath<Item, ID>,
-      onDismiss: (() -> Void)? = nil,
-      @ViewBuilder content: @escaping (Item) -> Content
-    ) -> some View {
-      self.sheet(item: item[id: id], onDismiss: onDismiss) { _ in
-        item.wrappedValue.map(content)
-      }
-    }
-
     /// Presents a sheet using a binding as a data source for the sheet's content.
     ///
     /// SwiftUI comes with a `sheet(item:)` view modifier that is powered by a binding to some
-    /// hashable state. When this state becomes non-`nil`, it passes an unwrapped value to the
+    /// identifiable state. When this state becomes non-`nil`, it passes an unwrapped value to the
     /// content closure. This value, however, is completely static, which prevents the sheet from
     /// modifying it.
     ///
-    /// This overload differs in that it passes a _binding_ to the content closure, instead. This
+    /// This overload differs in that it passes a _binding_ to the unwrapped value, instead. This
     /// gives the sheet the ability to write changes back to its source of truth.
     ///
-    /// Also unlike `sheet(item:)`, the binding's value does _not_ need to be hashable.
+    /// Also unlike `sheet(item:)`, the binding's value does _not_ need to be identifiable, and can
+    /// instead specify a key path to the provided data's identifier.
     ///
     /// ```swift
     /// struct TimelineView: View {
@@ -50,7 +29,7 @@
     ///     Button("Compose") {
     ///       self.draft = Post()
     ///     }
-    ///     .sheet(unwrapping: self.$draft) { $draft in
+    ///     .sheet(item: $draft, id: \.id) { $draft in
     ///       ComposeView(post: $draft, onSubmit: { ... })
     ///     }
     ///   }
@@ -63,23 +42,69 @@
     /// ```
     ///
     /// - Parameters:
-    ///   - value: A binding to an optional source of truth for the sheet. When `value` is
-    ///     non-`nil`, a non-optional binding to the value is passed to the `content` closure. You
-    ///     use this binding to produce content that the system presents to the user in a sheet.
-    ///     Changes made to the sheet's binding will be reflected back in the source of truth.
-    ///     Likewise, changes to `value` are instantly reflected in the sheet. If `value` becomes
-    ///     `nil`, the sheet is dismissed.
+    ///   - item: A binding to an optional source of truth for the sheet. When `item` is non-`nil`,
+    ///     the system passes the item's content to the modifier's closure. You display this content
+    ///     in a sheet that you create that the system displays to the user. If `item`'s identity
+    ///     changes, the system dismisses the sheet and replaces it with a new one using the same
+    ///     process.
+    ///   - id: The key path to the provided item's identifier.
     ///   - onDismiss: The closure to execute when dismissing the sheet.
     ///   - content: A closure returning the content of the sheet.
-    @MainActor
-    public func sheet<Value, Content>(
-      unwrapping value: Binding<Value?>,
+    @_disfavoredOverload
+    public func sheet<Item, ID: Hashable, Content: View>(
+      item: Binding<Item?>,
+      id: KeyPath<Item, ID>,
       onDismiss: (() -> Void)? = nil,
-      @ViewBuilder content: @escaping (Binding<Value>) -> Content
-    ) -> some View
-    where Content: View {
-      self.sheet(isPresented: value.isPresent(), onDismiss: onDismiss) {
-        Binding(unwrapping: value).map(content)
+      @ViewBuilder content: @escaping (Binding<Item>) -> Content
+    ) -> some View {
+      sheet(item: item[id: id], onDismiss: onDismiss) { _ in
+        Binding(unwrapping: item).map(content)
+      }
+    }
+
+    /// Presents a sheet using a binding as a data source for the sheet's content.
+    ///
+    /// A version of ``sheet(item:id:onDismiss:content:)-1hi9l`` that takes an identifiable item.
+    ///
+    /// - Parameters:
+    ///   - item: A binding to an optional source of truth for the sheet. When `item` is non-`nil`,
+    ///     the system passes the item's content to the modifier's closure. You display this content
+    ///     in a sheet that you create that the system displays to the user. If `item`'s identity
+    ///     changes, the system dismisses the sheet and replaces it with a new one using the same
+    ///     process.
+    ///   - onDismiss: The closure to execute when dismissing the sheet.
+    ///   - content: A closure returning the content of the sheet.
+    @_disfavoredOverload
+    public func sheet<Item: Identifiable, Content: View>(
+      item: Binding<Item?>,
+      onDismiss: (() -> Void)? = nil,
+      @ViewBuilder content: @escaping (Binding<Item>) -> Content
+    ) -> some View {
+      sheet(item: item, id: \.id, onDismiss: onDismiss, content: content)
+    }
+
+    /// Presents a sheet using a binding as a data source for the sheet's content.
+    ///
+    /// A version of ``sheet(item:id:onDismiss:content:)-1hi9l`` that is passed an item and not a
+    /// binding to an item.
+    ///
+    /// - Parameters:
+    ///   - item: A binding to an optional source of truth for the sheet. When `item` is non-`nil`,
+    ///     the system passes the item's content to the modifier's closure. You display this content
+    ///     in a sheet that you create that the system displays to the user. If `item`'s identity
+    ///     changes, the system dismisses the sheet and replaces it with a new one using the same
+    ///     process.
+    ///   - id: The key path to the provided item's identifier.
+    ///   - onDismiss: The closure to execute when dismissing the sheet.
+    ///   - content: A closure returning the content of the sheet.
+    public func sheet<Item, ID: Hashable, Content: View>(
+      item: Binding<Item?>,
+      id: KeyPath<Item, ID>,
+      onDismiss: (() -> Void)? = nil,
+      @ViewBuilder content: @escaping (Item) -> Content
+    ) -> some View {
+      sheet(item: item, id: id, onDismiss: onDismiss) {
+        content($0.wrappedValue)
       }
     }
   }


### PR DESCRIPTION
Some cleanup we discussed that is a long time coming. This PR:

- Deprecates all helpers that take `unwrapping:` parameters (except `Binding.init(unwrapping:)`).
- Defines `item:` overloads instead.
- Requires `sheet`, `popover` and `fullScreenCover` to take identifiable values _or_ a key path to identity.