### PR TITLE
Introduce `Binding<Bool>.init<V>(_: Binding<V?>)`

### DIFF
--- a/Examples/CaseStudies/09-CustomComponents.swift
+++ b/Examples/CaseStudies/09-CustomComponents.swift
@@ -98,7 +98,7 @@ extension View {
   where Content: View {
     modifier(
       BottomMenuModifier(
-        isActive: item.isPresent(),
+        isActive: Binding(item),
         content: { Binding(unwrapping: item).map(content) }
       )
     )

--- a/Sources/SwiftUINavigation/Internal/Deprecations.swift
+++ b/Sources/SwiftUINavigation/Internal/Deprecations.swift
@@ -19,7 +19,7 @@
     ) -> some View
     where Content: View {
       self.fullScreenCover(
-        isPresented: value.isPresent(),
+        isPresented: Binding(value),
         onDismiss: onDismiss
       ) {
         Binding(unwrapping: value).map(content)
@@ -41,12 +41,12 @@
       if requiresBindWorkaround {
         self.modifier(
           _NavigationDestinationBindWorkaround(
-            isPresented: value.isPresent(),
+            isPresented: Binding(value),
             destination: Binding(unwrapping: value).map(destination)
           )
         )
       } else {
-        self.navigationDestination(isPresented: value.isPresent()) {
+        self.navigationDestination(isPresented: Binding(value)) {
           Binding(unwrapping: value).map(destination)
         }
       }
@@ -92,7 +92,7 @@
       @ViewBuilder content: @escaping (Binding<Value>) -> Content
     ) -> some View {
       self.popover(
-        isPresented: value.isPresent(),
+        isPresented: Binding(value),
         attachmentAnchor: attachmentAnchor,
         arrowEdge: arrowEdge
       ) {
@@ -112,7 +112,7 @@
       @ViewBuilder content: @escaping (Binding<Value>) -> Content
     ) -> some View
     where Content: View {
-      self.sheet(isPresented: value.isPresent(), onDismiss: onDismiss) {
+      self.sheet(isPresented: Binding(value), onDismiss: onDismiss) {
         Binding(unwrapping: value).map(content)
       }
     }
@@ -132,7 +132,7 @@
     ) where Destination == WrappedDestination? {
       self.init(
         destination: Binding(unwrapping: value).map(destination),
-        isActive: value.isPresent().didSet(onNavigate),
+        isActive: Binding(value).didSet(onNavigate),
         label: label
       )
     }
@@ -164,7 +164,7 @@
     ) -> some View {
       self.confirmationDialog(
         value.wrappedValue.map(title) ?? Text(verbatim: ""),
-        isPresented: value.isPresent(),
+        isPresented: Binding(value),
         titleVisibility: titleVisibility,
         presenting: value.wrappedValue,
         actions: actions,
@@ -184,7 +184,7 @@
     ) -> some View {
       alert(
         (value.wrappedValue?.title).map(Text.init) ?? Text(verbatim: ""),
-        isPresented: value.isPresent(),
+        isPresented: Binding(value),
         presenting: value.wrappedValue,
         actions: {
           ForEach($0.buttons) {
@@ -202,7 +202,7 @@
     ) -> some View {
       alert(
         (value.wrappedValue?.title).map(Text.init) ?? Text(verbatim: ""),
-        isPresented: value.isPresent(),
+        isPresented: Binding(value),
         presenting: value.wrappedValue,
         actions: {
           ForEach($0.buttons) {
@@ -220,7 +220,7 @@
     ) -> some View {
       confirmationDialog(
         value.wrappedValue.flatMap { Text($0.title) } ?? Text(verbatim: ""),
-        isPresented: value.isPresent(),
+        isPresented: Binding(value),
         titleVisibility: value.wrappedValue.map { .init($0.titleVisibility) } ?? .automatic,
         presenting: value.wrappedValue,
         actions: {
@@ -239,7 +239,7 @@
     ) -> some View {
       confirmationDialog(
         value.wrappedValue.flatMap { Text($0.title) } ?? Text(verbatim: ""),
-        isPresented: value.isPresent(),
+        isPresented: Binding(value),
         titleVisibility: value.wrappedValue.map { .init($0.titleVisibility) } ?? .automatic,
         presenting: value.wrappedValue,
         actions: {
@@ -521,7 +521,7 @@
     )
     public func isPresent<Enum, Case>(_ casePath: AnyCasePath<Enum, Case>) -> Binding<Bool>
     where Value == Enum? {
-      self.case(casePath).isPresent()
+      .init(self.case(casePath))
     }
   }
 
@@ -1941,7 +1941,7 @@
     ) where Destination == WrappedDestination? {
       self.init(
         destination: Binding(unwrapping: value).map(destination),
-        isActive: value.isPresent().didSet(onNavigate),
+        isActive: Binding(value).didSet(onNavigate),
         label: label
       )
     }

--- a/Sources/SwiftUINavigation/Internal/Deprecations.swift
+++ b/Sources/SwiftUINavigation/Internal/Deprecations.swift
@@ -196,9 +196,9 @@
     }
 
     @available(*, deprecated, renamed: "alert(_:action:)")
-    public func alert<Value>(
+    public func alert<Value: Sendable>(
       unwrapping value: Binding<AlertState<Value>?>,
-      action handler: @escaping (Value?) async -> Void = { (_: Never?) async in }
+      action handler: @escaping @Sendable (Value?) async -> Void = { (_: Never?) async in }
     ) -> some View {
       alert(
         (value.wrappedValue?.title).map(Text.init) ?? Text(verbatim: ""),
@@ -233,9 +233,9 @@
     }
 
     @available(*, deprecated, renamed: "confirmationDialog(_:action:)")
-    public func confirmationDialog<Value>(
+    public func confirmationDialog<Value: Sendable>(
       unwrapping value: Binding<ConfirmationDialogState<Value>?>,
-      action handler: @escaping (Value?) async -> Void = { (_: Never?) async in }
+      action handler: @escaping @Sendable (Value?) async -> Void = { (_: Never?) async in }
     ) -> some View {
       confirmationDialog(
         value.wrappedValue.flatMap { Text($0.title) } ?? Text(verbatim: ""),
@@ -292,10 +292,10 @@
       message:
         "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
     )
-    public func alert<Enum, Value>(
+    public func alert<Enum, Value: Sendable>(
       unwrapping enum: Binding<Enum?>,
       case casePath: AnyCasePath<Enum, AlertState<Value>>,
-      action handler: @escaping (Value?) async -> Void = { (_: Never?) async in }
+      action handler: @escaping @Sendable (Value?) async -> Void = { (_: Never?) async in }
     ) -> some View {
       alert(`enum`.case(casePath), action: handler)
     }
@@ -343,10 +343,10 @@
       message:
         "Chain a '@CasePathable' enum binding into a case directly instead of specifying a case path."
     )
-    public func confirmationDialog<Enum, Value>(
+    public func confirmationDialog<Enum, Value: Sendable>(
       unwrapping enum: Binding<Enum?>,
       case casePath: AnyCasePath<Enum, ConfirmationDialogState<Value>>,
-      action handler: @escaping (Value?) async -> Void = { (_: Never?) async in }
+      action handler: @escaping @Sendable (Value?) async -> Void = { (_: Never?) async in }
     ) -> some View {
       confirmationDialog(
         `enum`.case(casePath),
@@ -767,7 +767,7 @@
     message:
       "Switch over a '@CasePathable' enum and derive bindings from each case using '$enum.case.map { $case in … }', instead."
   )
-  public struct CaseLet<Enum, Case, Content>: View
+  public struct CaseLet<Enum, Case, Content>: Sendable, View
   where Content: View {
     @EnvironmentObject private var `enum`: BindingObject<Enum>
     public let casePath: AnyCasePath<Enum, Case>
@@ -1847,9 +1847,9 @@
       message:
         "'View.alert' now passes an optional action to its handler to allow you to handle action-less dismissals."
     )
-    public func alert<Value>(
+    public func alert<Value: Sendable>(
       unwrapping value: Binding<AlertState<Value>?>,
-      action handler: @escaping (Value) async -> Void = { (_: Void) async in }
+      action handler: @escaping @Sendable (Value) async -> Void = { (_: Void) async in }
     ) -> some View {
       alert(value) { (value: Value?) in
         if let value = value {
@@ -1865,10 +1865,10 @@
       message:
         "'View.alert' now passes an optional action to its handler to allow you to handle action-less dismissals."
     )
-    public func alert<Enum, Value>(
+    public func alert<Enum, Value: Sendable>(
       unwrapping enum: Binding<Enum?>,
       case casePath: CasePath<Enum, AlertState<Value>>,
-      action handler: @escaping (Value) async -> Void = { (_: Void) async in }
+      action handler: @escaping @Sendable (Value) async -> Void = { (_: Void) async in }
     ) -> some View {
       alert(unwrapping: `enum`, case: casePath) { (value: Value?) async in
         if let value = value {
@@ -1884,9 +1884,9 @@
       message:
         "'View.alert' now passes an optional action to its handler to allow you to handle action-less dismissals."
     )
-    public func confirmationDialog<Value>(
+    public func confirmationDialog<Value: Sendable>(
       unwrapping value: Binding<ConfirmationDialogState<Value>?>,
-      action handler: @escaping (Value) async -> Void = { (_: Void) async in }
+      action handler: @escaping @Sendable (Value) async -> Void = { (_: Void) async in }
     ) -> some View {
       confirmationDialog(unwrapping: value) { (value: Value?) in
         if let value = value {
@@ -1902,10 +1902,10 @@
       message:
         "'View.alert' now passes an optional action to its handler to allow you to handle action-less dismissals."
     )
-    public func confirmationDialog<Enum, Value>(
+    public func confirmationDialog<Enum, Value: Sendable>(
       unwrapping enum: Binding<Enum?>,
       case casePath: CasePath<Enum, ConfirmationDialogState<Value>>,
-      action handler: @escaping (Value) async -> Void = { (_: Void) async in }
+      action handler: @escaping @Sendable (Value) async -> Void = { (_: Void) async in }
     ) -> some View {
       confirmationDialog(unwrapping: `enum`, case: casePath) { (value: Value?) async in
         if let value = value {

--- a/Sources/SwiftUINavigation/NavigationLink.swift
+++ b/Sources/SwiftUINavigation/NavigationLink.swift
@@ -62,7 +62,7 @@
     ) where Destination == WrappedDestination? {
       self.init(
         destination: Binding(unwrapping: item).map(destination),
-        isActive: item.isPresent().didSet(onNavigate),
+        isActive: Binding(item).didSet(onNavigate),
         label: label
       )
     }

--- a/Sources/SwiftUINavigationCore/Alert.swift
+++ b/Sources/SwiftUINavigationCore/Alert.swift
@@ -67,7 +67,7 @@
     ) -> some View {
       alert(
         item.wrappedValue.map(title) ?? Text(verbatim: ""),
-        isPresented: item.isPresent(),
+        isPresented: Binding(item),
         presenting: item.wrappedValue,
         actions: actions,
         message: message
@@ -132,7 +132,7 @@
     ) -> some View {
       alert(
         item.wrappedValue.map(title) ?? Text(verbatim: ""),
-        isPresented: item.isPresent(),
+        isPresented: Binding(item),
         presenting: item.wrappedValue,
         actions: actions
       )

--- a/Sources/SwiftUINavigationCore/AlertState.swift
+++ b/Sources/SwiftUINavigationCore/AlertState.swift
@@ -219,6 +219,18 @@
 
   // MARK: - SwiftUI bridging
 
+  @available(
+    iOS, introduced: 13, deprecated: 100000, message: "use 'View.alert(_:action:)' instead."
+  )
+  @available(
+    macOS, introduced: 10.15, deprecated: 100000, message: "use 'View.alert(_:action:)' instead."
+  )
+  @available(
+    tvOS, introduced: 13, deprecated: 100000, message: "use 'View.alert(_:action:)' instead."
+  )
+  @available(
+    watchOS, introduced: 6, deprecated: 100000, message: "use 'View.alert(_:action:)' instead."
+  )
   extension Alert {
     /// Creates an alert from alert state.
     ///

--- a/Sources/SwiftUINavigationCore/Binding.swift
+++ b/Sources/SwiftUINavigationCore/Binding.swift
@@ -2,15 +2,13 @@
   import SwiftUI
 
   extension Binding {
-    /// Creates a binding by projecting the current optional value to a boolean describing if it's
-    /// non-`nil`.
+    /// Creates a binding by projecting the base optional value to a Boolean value.
     ///
     /// Writing `false` to the binding will `nil` out the base value. Writing `true` does nothing.
     ///
-    /// - Returns: A binding to a boolean. Returns `true` if non-`nil`, otherwise `false`.
-    public func isPresent<Wrapped>() -> Binding<Bool>
-    where Value == Wrapped? {
-      self._isPresent
+    /// - Parameter base: A value to project to a Boolean value.
+    public init<V>(_ base: Binding<V?>) where Value == Bool {
+      self = base._isPresent
     }
   }
 
@@ -23,5 +21,4 @@
       }
     }
   }
-
 #endif

--- a/Sources/SwiftUINavigationCore/ConfirmationDialog.swift
+++ b/Sources/SwiftUINavigationCore/ConfirmationDialog.swift
@@ -70,7 +70,7 @@
     ) -> some View {
       confirmationDialog(
         item.wrappedValue.map(title) ?? Text(verbatim: ""),
-        isPresented: item.isPresent(),
+        isPresented: Binding(item),
         titleVisibility: titleVisibility,
         presenting: item.wrappedValue,
         actions: actions,
@@ -140,7 +140,7 @@
     ) -> some View {
       confirmationDialog(
         item.wrappedValue.map(title) ?? Text(verbatim: ""),
-        isPresented: item.isPresent(),
+        isPresented: Binding(item),
         titleVisibility: titleVisibility,
         presenting: item.wrappedValue,
         actions: actions

--- a/Sources/SwiftUINavigationCore/Documentation.docc/Extensions/AlertState.md
+++ b/Sources/SwiftUINavigationCore/Documentation.docc/Extensions/AlertState.md
@@ -1,0 +1,22 @@
+# ``SwiftUINavigationCore/AlertState``
+
+## Topics
+
+### Creating alerts
+
+- ``init(title:actions:message:)``
+
+### Reading alert data
+
+- ``id``
+- ``title``
+- ``message``
+- ``buttons``
+
+### Transforming alerts
+
+- ``map(_:)``
+
+### Deprecations
+
+- <doc:AlertStateDeprecations>

--- a/Sources/SwiftUINavigationCore/Documentation.docc/Extensions/AlertStateDeprecations.md
+++ b/Sources/SwiftUINavigationCore/Documentation.docc/Extensions/AlertStateDeprecations.md
@@ -1,0 +1,22 @@
+# Deprecations
+
+Review unsupported SwiftUI Navigation APIs and their replacements.
+
+## Overview
+
+Avoid using deprecated APIs in your app. Select a method to see the replacement that you should use
+instead.
+
+## Topics
+
+### Creating alerts
+
+- ``AlertState/init(title:message:primaryButton:secondaryButton:)``
+- ``AlertState/init(title:message:dismissButton:)``
+- ``AlertState/init(title:message:buttons:)``
+
+### Supporting types
+
+- ``AlertState/Button``
+- ``AlertState/ButtonAction``
+- ``AlertState/ButtonRole``

--- a/Sources/SwiftUINavigationCore/Documentation.docc/Extensions/ButtonState.md
+++ b/Sources/SwiftUINavigationCore/Documentation.docc/Extensions/ButtonState.md
@@ -1,0 +1,36 @@
+# ``SwiftUINavigationCore/ButtonState``
+
+## Topics
+
+### Creating buttons
+
+- ``init(role:action:label:)-99wi3``
+- ``init(role:action:label:)-2ixoi``
+- ``ButtonStateRole``
+- ``ButtonStateAction``
+
+### Composing buttons
+
+- ``ButtonStateBuilder``
+
+### Reading button data
+
+- ``id``
+- ``role-swift.property``
+- ``action``
+- ``label``
+
+### Performing actions
+
+- ``withAction(_:)-56ifj``
+- ``withAction(_:)-71nj4``
+
+### Transforming buttons
+
+- ``SwiftUI/Button``
+- ``SwiftUI/ButtonRole``
+- ``map(_:)``
+
+### Deprecations
+
+- <doc:ButtonStateDeprecations>

--- a/Sources/SwiftUINavigationCore/Documentation.docc/Extensions/ButtonStateDeprecations.md
+++ b/Sources/SwiftUINavigationCore/Documentation.docc/Extensions/ButtonStateDeprecations.md
@@ -1,0 +1,24 @@
+# Deprecations
+
+Review unsupported SwiftUI Navigation APIs and their replacements.
+
+## Overview
+
+Avoid using deprecated APIs in your app. Select a method to see the replacement that you should use
+instead.
+
+## Topics
+
+### Creating buttons
+
+- ``ButtonState/cancel(_:action:)``
+- ``ButtonState/default(_:action:)``
+- ``ButtonState/destructive(_:action:)``
+
+### Readin
+
+### Supporting types
+
+- ``ButtonState/ButtonAction``
+- ``ButtonState/Handler``
+- ``ButtonState/Role-swift.typealias``

--- a/Sources/SwiftUINavigationCore/Documentation.docc/Extensions/ConfirmationDialogState.md
+++ b/Sources/SwiftUINavigationCore/Documentation.docc/Extensions/ConfirmationDialogState.md
@@ -1,0 +1,26 @@
+# ``SwiftUINavigationCore/ConfirmationDialogState``
+
+## Topics
+
+### Creating dialogs
+
+- ``init(title:actions:message:)``
+- ``init(titleVisibility:title:actions:message:)``
+- ``ConfirmationDialogStateTitleVisibility``
+
+### Reading dialog data
+
+- ``id``
+- ``title``
+- ``titleVisibility``
+- ``message``
+- ``buttons``
+
+### Transforming dialogs
+
+- ``map(_:)``
+- ``SwiftUI/Visibility``
+
+### Deprecations
+
+- <doc:ConfirmationDialogStateDeprecations>

--- a/Sources/SwiftUINavigationCore/Documentation.docc/Extensions/ConfirmationDialogStateDeprecations.md
+++ b/Sources/SwiftUINavigationCore/Documentation.docc/Extensions/ConfirmationDialogStateDeprecations.md
@@ -1,0 +1,21 @@
+# Deprecations
+
+Review unsupported SwiftUI Navigation APIs and their replacements.
+
+## Overview
+
+Avoid using deprecated APIs in your app. Select a method to see the replacement that you should use
+instead.
+
+## Topics
+
+### Creating dialogs
+
+- ``ActionSheetState``
+- ``ConfirmationDialogState/init(title:message:buttons:)``
+- ``ConfirmationDialogState/init(title:titleVisibility:message:buttons:)``
+
+### Supporting types
+
+- ``ConfirmationDialogState/Button``
+- ``ConfirmationDialogState/Visibility``

--- a/Sources/SwiftUINavigationCore/Documentation.docc/Extensions/Deprecations.md
+++ b/Sources/SwiftUINavigationCore/Documentation.docc/Extensions/Deprecations.md
@@ -1,0 +1,19 @@
+# Deprecations
+
+Review unsupported SwiftUI Navigation APIs and their replacements.
+
+## Overview
+
+Avoid using deprecated APIs in your app. Select a method to see the replacement that you should use
+instead.
+
+## Topics
+
+### Bindings
+
+- ``SwiftUI/Binding/isPresent()``
+
+### Alerts and dialogs
+
+- ``SwiftUI/ActionSheet/init(_:action:)``
+- ``SwiftUI/Alert``

--- a/Sources/SwiftUINavigationCore/Documentation.docc/Extensions/TextState.md
+++ b/Sources/SwiftUINavigationCore/Documentation.docc/Extensions/TextState.md
@@ -1,0 +1,14 @@
+# ``SwiftUINavigationCore/TextState``
+
+## Topics
+
+### Creating text state
+
+- ``init(_:)``
+- ``init(_:tableName:bundle:comment:)``
+- ``init(verbatim:)``
+
+### Text state transformations
+
+- ``SwiftUI/Text``
+- ``Swift/String``

--- a/Sources/SwiftUINavigationCore/Documentation.docc/SwiftUINavigationCore.md
+++ b/Sources/SwiftUINavigationCore/Documentation.docc/SwiftUINavigationCore.md
@@ -20,9 +20,13 @@ A few core types and modifiers included in SwiftUI Navigation.
 
 ### Bindings
 
-- ``SwiftUI/Binding/isPresent()``
+- ``SwiftUI/Binding/init(_:)``
 - ``SwiftUI/View/bind(_:to:)``
 
 ### Navigation
 
 - ``SwiftUI/View/navigationDestination(item:destination:)``
+
+### Deprecations
+
+- <doc:Deprecations>

--- a/Sources/SwiftUINavigationCore/Internal/Deprecations.swift
+++ b/Sources/SwiftUINavigationCore/Internal/Deprecations.swift
@@ -1,6 +1,19 @@
 #if canImport(SwiftUI)
   import SwiftUI
 
+  // NB: Deprecated after 1.4.0
+
+  extension Binding {
+    @available(
+      *, deprecated,
+      message: "Use 'Binding.init(_:)' to project an optional binding to a Boolean, instead."
+    )
+    public func isPresent<Wrapped>() -> Binding<Bool>
+    where Value == Wrapped? {
+      Binding<Bool>(self)
+    }
+  }
+
   // NB: Deprecated after 0.5.0
 
   extension ButtonState {

--- a/Sources/SwiftUINavigationCore/NavigationDestination.swift
+++ b/Sources/SwiftUINavigationCore/NavigationDestination.swift
@@ -15,7 +15,7 @@
       item: Binding<D?>,
       @ViewBuilder destination: @escaping (D) -> C
     ) -> some View {
-      navigationDestination(isPresented: item.isPresent()) {
+      navigationDestination(isPresented: Binding(item)) {
         if let item = item.wrappedValue {
           destination(item)
         }


### PR DESCRIPTION
We currently have an `isPresent()` method for transforming bindings, but it seems to be an outlier compared to most binding transformations that come with SwiftUI, which use initializers.

While updating docs I noticed the core module wasn't really organized at all, so took a quick pass.