### PR TITLE
Pass `CI` environment variable to `xcodebuild`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ PLATFORM_MACOS = macOS
 PLATFORM_TVOS = tvOS Simulator,name=Apple TV
 PLATFORM_WATCHOS = watchOS Simulator,name=Apple Watch Series 7 (45mm)
 
+TEST_RUNNER_CI = $(CI)
+
 default: test
 
 test:


### PR DESCRIPTION
Apparently Xcode 15.3+ only makes environment variables prefixed with `TEST_RUNNER_` available to tests:

https://forums.developer.apple.com/forums/thread/749185