### PR TITLE
Dismiss correct view controller when doing presentation.

### DIFF
--- a/Examples/CaseStudiesTests/PresentationTests.swift
+++ b/Examples/CaseStudiesTests/PresentationTests.swift
@@ -324,13 +324,52 @@ final class PresentationTests: XCTestCase {
     await assertEventuallyNil(vc.presentedViewController, timeout: 2)
   }
 
+
+  @MainActor
+  func testDismissLeafPresentationDirectly() async throws {
+    class VC: UIViewController {
+      @UIBinding var isPresented = false
+      override func loadView() {
+        super.loadView()
+        view.backgroundColor = .init(
+          red: .random(in: 0...1),
+          green: .random(in: 0...1),
+          blue: .random(in: 0...1),
+          alpha: 1
+        )
+      }
+      override func viewDidLoad() {
+        super.viewDidLoad()
+        present(isPresented: $isPresented) { VC() }
+      }
+    }
+
+    let vc = VC()
+    try await setUp(controller: vc)
+
+    vc.isPresented = true
+    await assertEventuallyNotNil(vc.presentedViewController)
+
+    try XCTUnwrap(vc.presentedViewController as? VC).isPresented = true
+    await assertEventuallyNotNil(vc.presentedViewController?.presentedViewController)
+
+    vc.presentedViewController?.presentedViewController?.dismiss(animated: false)
+    try await Task.sleep(for: .seconds(0.5))
+    await assertEventuallyNotNil(vc.presentedViewController timeout: 2)
+  }
+
   @MainActor
   func testDismissMiddlePresentation() async throws {
     class VC: UIViewController {
       @UIBinding var isPresented = false
       override func loadView() {
         super.loadView()
-        view.backgroundColor = .init(red: .random(in: 0...1), green: .random(in: 0...1), blue: .random(in: 0...1), alpha: 1)
+        view.backgroundColor = .init(
+          red: .random(in: 0...1),
+          green: .random(in: 0...1),
+          blue: .random(in: 0...1),
+          alpha: 1
+        )
       }
       override func viewDidLoad() {
         super.viewDidLoad()

--- a/Sources/UIKitNavigation/Navigation/Presentation.swift
+++ b/Sources/UIKitNavigation/Navigation/Presentation.swift
@@ -127,7 +127,7 @@
         } else {
           self?.present(newController, animated: !transaction.uiKit.disablesAnimations)
         }
-      } dismiss: { parent, child, transaction in
+      } dismiss: { parent, _, transaction in
         parent.dismiss(animated: !transaction.uiKit.disablesAnimations) {
           onDismiss?()
         }


### PR DESCRIPTION
Currently the dismissal logic for a `present` and `navigationDestination` are very similar. We take the "presented" controller and either invoke `dismiss()` on it or we `popFromViewController` on it. However, dismissal in a presentation context is subtly different from a push context.

If you do `controller.dismiss()` on a view controller, it does one of two things:

* If `controller` is not presenting anything, it dismisses itself from the parent.
* If `controller` is presenting something, it dismisses that.

So, in a presentation context it is more correct to actually call `dismiss` on the parent controller, not the child as we do now. Whereas in a push context it is more correct to call `popFrom…` on the child controller.

This all just means that we need to beef up the "one true destination" API so that upon dismissal we are given both the parent and child controllers so that we can decide what we want to do depending on the type of navigation taking place. This could probably help with custom controller containment patterns too.