### PR TITLE
Point Issue Reporting to xctest-dynamic-overlay repo

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "031704ba0634b45e02fe875b8ddddc7f30a07f49",
-        "version" : "1.5.3"
+        "branch" : "xct-name",
+        "revision" : "593151ec13a564a79dc930cf57c82a67355b76c2"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "d237304f42af07f22563aa4cc2d7e2cfb25da82e",
-        "version" : "1.3.1"
+        "branch" : "xct-name",
+        "revision" : "3af72bba805d9d91aecdc5c0df15d5f8b89de8de"
       }
     },
     {
@@ -37,21 +37,21 @@
       }
     },
     {
-      "identity" : "swift-issue-reporting",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-issue-reporting",
-      "state" : {
-        "revision" : "926f43898706eaa127db79ac42138e1ad7e85a3f",
-        "version" : "1.2.0"
-      }
-    },
-    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
         "revision" : "4c6cc0a3b9e8f14b3ae2307c5ccae4de6167ac2c",
         "version" : "600.0.0-prerelease-2024-06-12"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "357ca1e5dd31f613a1d43320870ebc219386a495",
+        "version" : "1.2.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -22,9 +22,9 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-    .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.5.3"),
-    .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.1"),
-    .package(url: "https://github.com/pointfreeco/swift-issue-reporting", from: "1.2.0"),
+    .package(url: "https://github.com/pointfreeco/swift-case-paths", branch: "xct-name"),
+    .package(url: "https://github.com/pointfreeco/swift-custom-dump", branch: "xct-name"),
+    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.2.2"),
   ],
   targets: [
     .target(
@@ -32,7 +32,7 @@ let package = Package(
       dependencies: [
         "SwiftUINavigationCore",
         .product(name: "CasePaths", package: "swift-case-paths"),
-        .product(name: "IssueReporting", package: "swift-issue-reporting"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
       ]
     ),
     .testTarget(
@@ -45,7 +45,7 @@ let package = Package(
       name: "SwiftUINavigationCore",
       dependencies: [
         .product(name: "CustomDump", package: "swift-custom-dump"),
-        .product(name: "IssueReporting", package: "swift-issue-reporting"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
       ]
     ),
   ]

--- a/SwiftUINavigation.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SwiftUINavigation.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "031704ba0634b45e02fe875b8ddddc7f30a07f49",
-        "version" : "1.5.3"
+        "branch" : "xct-name",
+        "revision" : "593151ec13a564a79dc930cf57c82a67355b76c2"
       }
     },
     {
@@ -39,7 +39,7 @@
     {
       "identity" : "swift-concurrency-extras",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras.git",
       "state" : {
         "revision" : "bb5059bde9022d69ac516803f4f227d8ac967f71",
         "version" : "1.1.0"
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "d237304f42af07f22563aa4cc2d7e2cfb25da82e",
-        "version" : "1.3.1"
+        "branch" : "xct-name",
+        "revision" : "3af72bba805d9d91aecdc5c0df15d5f8b89de8de"
       }
     },
     {
@@ -115,6 +115,15 @@
       "state" : {
         "revision" : "3907a9438f5b57d317001dc99f3f11b46882272b",
         "version" : "0.10.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "357ca1e5dd31f613a1d43320870ebc219386a495",
+        "version" : "1.2.2"
       }
     }
   ],


### PR DESCRIPTION
Swift Package Manager honors redirects, but it appears to associate the path suffix with the package name, and this conflicts with package resolution in certain (but not all) cases.

I think we have no choice but to roll back everything to point to the original xctest-dynamic-overlay URL and extract Issue Reporting to a dedicated repo.